### PR TITLE
Stop building igvc_msgs before all

### DIFF
--- a/config.docif
+++ b/config.docif
@@ -90,7 +90,6 @@ SETUP_SHA_FILES+=("./igvc/package.xml")
 # Commands are in this format
 # COMMAND; SHORT_NAME; DESCRIPTION
 TEST_COMMANDS=()
-TEST_COMMANDS+=( 'catkin_make igvc_msgs_gencpp;hack;A dummy test to fix broken dependencies' )
 TEST_COMMANDS+=( 'catkin_make;compile;A check to see if the code compiles' )
 TEST_COMMANDS+=( 'catkin_make run_tests;tests;A check to see if the tests pass' )
 


### PR DESCRIPTION
See #40 

Because that was fixed, you guys don't need a hack build target.