### PR TITLE
missing dependency 

### DIFF
--- a/igvc/CMakeLists.txt
+++ b/igvc/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   std_msgs
   igvc_msgs
+  image_geometry
   image_transport
   cv_bridge
   camera_info_manager

--- a/igvc/package.xml
+++ b/igvc/package.xml
@@ -44,7 +44,6 @@
   <build_depend>roslib</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>class_loader</build_depend>
-  <build_depend>image_geometry</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>image_transport</run_depend>
@@ -59,7 +58,6 @@
   <run_depend>class_loader</run_depend>
   <run_depend>pluginlib</run_depend>
   <run_depend>class_loader</run_depend>
-  <run_depend>image_geometry</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/igvc/package.xml
+++ b/igvc/package.xml
@@ -44,6 +44,7 @@
   <build_depend>roslib</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>class_loader</build_depend>
+  <build_depend>image_geometry</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>image_transport</run_depend>
@@ -58,6 +59,7 @@
   <run_depend>class_loader</run_depend>
   <run_depend>pluginlib</run_depend>
   <run_depend>class_loader</run_depend>
+  <run_depend>image_geometry</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
the ros dependency image_geometry is missing from our deps but it is used in both line detector and pot hole detector