### PR TITLE
Added usb_cam submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "external/DoCIF"]
 	path = external/DoCIF
 	url = https://github.com/jgkamat/DoCIF.git
+[submodule "external/usb_cam"]
+	path = external/usb_cam
+	url = https://github.com/bosch-ros-pkg/usb_cam.git


### PR DESCRIPTION
This is to publish data from camera devices. ROS kinetic does not have usb_cam yet.
See https://github.com/bosch-ros-pkg/usb_cam/issues/53