### PR TITLE
Added maxDistance parameter for line detector

### DIFF
--- a/igvc/include/igvc/CVUtils.hpp
+++ b/igvc/include/igvc/CVUtils.hpp
@@ -24,11 +24,6 @@ pcl::PointXYZ PointFromPixelNoCam(const cv::Point& p, int height, int width, dou
   return pcl::PointXYZ(x, y, 0);
 }
 
-double toRadians(double degrees)
-{
-  return degrees / 180.0 * M_PI;
-}
-
 std::vector<std::vector<cv::Point>> MatToContours(const cv::Mat img) {
     std::vector<std::vector<cv::Point>> contours;
     for(int r = 0; r < img.rows; r++) {
@@ -49,6 +44,17 @@ bool replace(std::string& str, const std::string& from, const std::string& to) {
         return false;
     str.replace(start_pos, from.length(), to);
     return true;
+}
+
+void capPointCloud(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud, int cap) {
+  pcl::PointCloud<pcl::PointXYZ>::iterator it;
+  for (it = cloud->begin(); it < cloud->end();) {
+    if (it->x > cap) {
+      it = cloud->erase(it);
+    } else {
+      it++;
+    }
+  }
 }
 
 pcl::PointCloud<pcl::PointXYZ>::Ptr toPointCloud(tf::TransformListener &tf_listener, std::vector<std::vector<cv::Point>> contours, image_geometry::PinholeCameraModel cam, std::string topic) {

--- a/igvc/src/line_detector/linedetector.cpp
+++ b/igvc/src/line_detector/linedetector.cpp
@@ -45,6 +45,10 @@ void LineDetector::img_callback(const sensor_msgs::ImageConstPtr& msg) {
     cv::vconcat(black, fin_img, fin_img);
     
     cloud = toPointCloud(tf_listener, MatToContours(fin_img), cam, topic);
+
+    // Limit how far the points are plotted in the cloud
+    capPointCloud(cloud, maxDistance);
+    
     _line_cloud.publish(cloud);
     
     cv::cvtColor(fin_img, fin_img, CV_GRAY2BGR);    
@@ -66,4 +70,5 @@ LineDetector::LineDetector(ros::NodeHandle& handle, const std::string& topic)
     handle.getParam(ros::this_node::getName() + "/config/line/houghThreshold", houghThreshold);
     handle.getParam(ros::this_node::getName() + "/config/line/houghMinLineLength", houghMinLineLength);
     handle.getParam(ros::this_node::getName() + "/config/line/houghMaxLineGap", houghMaxLineGap);
+    handle.getParam(ros::this_node::getName() + "/config/line/maxDistance", maxDistance);
 }

--- a/igvc/src/line_detector/linedetector.h
+++ b/igvc/src/line_detector/linedetector.h
@@ -34,6 +34,7 @@ private:
   int houghThreshold;
   int houghMinLineLength;
   int houghMaxLineGap;
+  int maxDistance;
 };
 
 #endif  // LINEDETECTOR_H

--- a/sandbox/detectors_config_gazebo.yaml
+++ b/sandbox/detectors_config_gazebo.yaml
@@ -30,3 +30,6 @@ config:
     houghThreshold: 80
     houghMinLineLength: 35
     houghMaxLineGap: 15
+
+    # The maximum forward distance from the robot to plot points in meters
+    maxDistance: 8

--- a/sandbox/detectors_config_realworld.yaml
+++ b/sandbox/detectors_config_realworld.yaml
@@ -1,4 +1,4 @@
-# Configuration values for our OpenCV nodes tuned for a GAZEBO SIMULATION
+# Configuration values for our OpenCV nodes tuned for the REAL WORLD
 config:
 
   # Pothole Detector configuration values
@@ -26,7 +26,10 @@ config:
     cannyThresh1: 45
     cannyThresh2: 135
 
-    # HoughCirclesP tunable values
+    # HoughLinesP tunable values
     houghThreshold: 80
     houghMinLineLength: 35
     houghMaxLineGap: 15
+
+    # The maximum forward distance from the robot to plot points in meters
+    maxDistance: 8


### PR DESCRIPTION
The maxDistance specified will limit the forward distance for any points plotted in the point cloud by the line detector.