### PR TITLE
rviz plugins setup

### DIFF
--- a/igvc_rviz_plugins/CMakeLists.txt
+++ b/igvc_rviz_plugins/CMakeLists.txt
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(igvc_rviz_plugins)
+
+SET(CMAKE_CXX_STANDARD 14)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  rviz
+  igvc_msgs
+)
+
+find_package(Qt5Widgets REQUIRED)
+
+###################################
+## catkin specific configuration ##
+###################################
+
+catkin_package(
+  LIBRARIES ${PROJECT_NAME}
+  CATKIN_DEPENDS roscpp rviz igvc_msgs
+)
+
+###########
+## Build ##
+###########
+
+
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+set (rviz_plugins_SRCS
+    src/ExamplePanel.cpp
+)
+
+set (rviz_plugins_HDRS
+    include/igvc_rviz_plugins/ExamplePanel.h
+)
+
+qt5_wrap_cpp(rviz_plugins_MOCS ${rviz_plugins_HDRS})
+
+add_library(${PROJECT_NAME} ${rviz_plugins_SRCS} ${rviz_plugins_MOCS})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} Qt5::Widgets)
+add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+#############
+## Install ##
+#############
+
+install(FILES
+  plugin_description.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/igvc_rviz_plugins/HOWTO.md
+++ b/igvc_rviz_plugins/HOWTO.md
@@ -1,0 +1,14 @@
+# How To Make an rviz Panel
+
+All rviz panels are classes that inherit from rviz::Panel. Any catkin package can export a class library defining its own set of Panel subclasses, allowing packages to create their own custom rviz panels.
+
+To create your own panel, follow these general steps:
+
+1. Create a new subclass of rviz::Panel in the `igvc_rviz_plugins` namespace.
+2. Implement your panel and add the `PLUGINLIB_EXPORT_CLASS(...)` macro to the end of your *.cpp file.
+3. Add your *.h and *.cpp files to `rviz_plugins_HDRS` and `rviz_plugins_SRCS` in *CMakeLists.txt*.
+4. Add a new <class> tag to *igvc_rviz_plugins*'s *plugin_description.xml* file.
+
+That's it! At this point, you should be able to build the package with `catkin_make` in your catkin workspace. Your new panel will show up in rviz when you click *Panels->Add New Panel*.
+
+To see more details about how to implement an rviz panel, check out *ExamplePanel.h* and *ExamplePanel.cpp*.

--- a/igvc_rviz_plugins/include/igvc_rviz_plugins/ExamplePanel.h
+++ b/igvc_rviz_plugins/include/igvc_rviz_plugins/ExamplePanel.h
@@ -1,0 +1,54 @@
+#ifndef PROJECT_EXAMPLEPANEL_H
+#define PROJECT_EXAMPLEPANEL_H
+
+#include <ros/ros.h>
+#include <rviz/panel.h>
+#include <igvc_msgs/velocity_pair.h>
+#include <QLabel>
+
+/*
+ * All of our panels need to be under the igvc_rviz_plugins namespace.
+ */
+namespace igvc_rviz_plugins {
+
+/*
+ * Each panel is a subclass of rviz::Panel
+ */
+class ExamplePanel : public rviz::Panel {
+/*
+ * rviz is based on QT, so our panels need to be QObjects, which requires this macro keyword.
+ */
+Q_OBJECT
+public:
+
+    /**
+     * This is a standard QWidget constructor.
+     * @param parent The parent widget, which will be responsible for the lifetime of this widget.
+     */
+    ExamplePanel(QWidget *parent = 0);
+
+protected:
+    /*
+     * Be sure to make any publishers / subscribers members of the class. This will keep them alive throughout
+     * the lifetime of the widget.
+     */
+    ros::Subscriber speed_subscriber;
+
+    /**
+     * Declare any ROS callbacks you need here. Be sure to create a parameter for any UI elements you need to update.
+     * @param msg The ROS message that triggers this callback.
+     * @param label A QT label whose text we will update based on the message contents.
+     */
+    void speed_callback(const igvc_msgs::velocity_pairConstPtr &msg, QLabel *label);
+
+    /**
+     * If you need to paint custom graphics on your panel, uncomment and implement the paintEvent method.
+     * You can find out more about this method here: http://doc.qt.io/qt-5/qwidget.html#paintEvent
+     */
+//    void paintEvent(QPaintEvent *event) override;
+
+};
+
+}
+
+#endif //PROJECT_EXAMPLEPANEL_H

--- a/igvc_rviz_plugins/package.xml
+++ b/igvc_rviz_plugins/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<package>
+  <name>igvc_rviz_plugins</name>
+  <version>0.0.0</version>
+  <description>Rviz plugins for IGVC</description>
+
+  <maintainer email="matthew.barulic@gmail.com">Matthew Barulic</maintainer>
+  <maintainer email="chaussee.al@gmail.com">Al Chaussee</maintainer>
+
+  <license>MIT</license>
+
+  <url type="website">http://www.robojackets.org</url>
+  <url type="website">http://www.github.com/robojackets/igvc-software</url>
+  <url type="website">http://robojackets.github.io/igvc-software</url>
+  <url type="website">http://www.noruts.com</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>roscpp</build_depend>
+  <build_depend>rviz</build_depend>
+  <build_depend>igvc_msgs</build_depend>
+
+  <run_depend>roscpp</run_depend>
+  <run_depend>rviz</run_depend>
+  <run_depend>igvc_msgs</run_depend>
+
+  <export>
+    <rviz plugin="${prefix}/plugin_description.xml"/>
+  </export>
+</package>

--- a/igvc_rviz_plugins/plugin_description.xml
+++ b/igvc_rviz_plugins/plugin_description.xml
@@ -1,0 +1,9 @@
+<library path="lib/libigvc_rviz_plugins">
+    <class name="igvc_rviz_plugins/ExamplePanel"
+           type="igvc_rviz_plugins::ExamplePanel"
+           base_class_type="rviz::Panel">
+        <description>
+            Example panel for getting started
+        </description>
+    </class>
+</library>

--- a/igvc_rviz_plugins/src/ExamplePanel.cpp
+++ b/igvc_rviz_plugins/src/ExamplePanel.cpp
@@ -1,0 +1,49 @@
+#include <igvc_rviz_plugins/ExamplePanel.h>
+#include <QVBoxLayout>
+#include <pluginlib/class_list_macros.h>
+
+/*
+ * Just as in the header, everything needs to happen in the igvc_rviz_plugins namespace.
+ */
+namespace igvc_rviz_plugins {
+
+ExamplePanel::ExamplePanel(QWidget *parent)
+  : rviz::Panel(parent) // Base class constructor
+{
+    // Panels are allowed to interact with NodeHandles directly just like ROS nodes.
+    ros::NodeHandle handle;
+
+    // Initialize a label for displaying some data
+    QLabel *label = new QLabel("0 m/s");
+
+    /* Initialize our subscriber to listen to the /speed topic.
+    * Note the use of boost::bind, which allows us to give the callback a pointer to our UI label.
+    */
+    speed_subscriber = handle.subscribe<igvc_msgs::velocity_pair>("/encoders", 1, boost::bind(&ExamplePanel::speed_callback, this, _1, label));
+
+    /* Use QT layouts to add widgets to the panel.
+    * Here, we're using a VBox layout, which allows us to stack all of our widgets vertically.
+    */
+    QVBoxLayout *layout = new QVBoxLayout;
+    layout->addWidget(label);
+    setLayout(layout);
+}
+
+void ExamplePanel::speed_callback(const igvc_msgs::velocity_pairConstPtr &msg, QLabel *label) {
+    // Create the new contents of the label based on the speed message.
+    auto text = "Left: " + std::to_string(msg->left_velocity) + " m/s\n" +
+                "Right: " + std::to_string(msg->right_velocity) + " m/s";
+    // Set the contents of the label.
+    label->setText(text.c_str());
+}
+
+//void ExamplePanel::paintEvent(QPaintEvent *event)  {
+//
+//}
+
+}
+
+/*
+ * IMPORTANT! This macro must be filled out correctly for your panel class.
+ */
+PLUGINLIB_EXPORT_CLASS( igvc_rviz_plugins::ExamplePanel, rviz::Panel)


### PR DESCRIPTION
Adds the igvc_rviz_plugins package with catkin setup for rviz plugins.
Adds ExamplePanel which displays the speeds published on the /encoders topic.
Fixes #250 