### PR TITLE
Fixes some minor bugs in the model setup for Gazebo.

### DIFF
--- a/gazebo/igvc_description/package.xml
+++ b/gazebo/igvc_description/package.xml
@@ -24,4 +24,9 @@
   <run_depend>hector_gazebo_worlds</run_depend>
   <run_depend>joy</run_depend>
   <run_depend>rviz</run_depend>
+  
+  <export>
+    <gazebo_ros gazebo_model_path="${prefix}/urdf/models"/>
+    <gazebo_ros gazebo_media_path="${prefix}/urdf/models"/>
+  </export>
 </package>

--- a/gazebo/igvc_description/urdf/models/construction_barrel/model.config
+++ b/gazebo/igvc_description/urdf/models/construction_barrel/model.config
@@ -1,4 +1,3 @@
-
 <?xml version="1.0"?>
 
 <model>

--- a/gazebo/igvc_description/urdf/models/grass_plane/model.config
+++ b/gazebo/igvc_description/urdf/models/grass_plane/model.config
@@ -1,4 +1,3 @@
-
 <?xml version="1.0"?>
 
 <model>

--- a/gazebo/igvc_description/urdf/models/sun/model.config
+++ b/gazebo/igvc_description/urdf/models/sun/model.config
@@ -1,4 +1,3 @@
-
 <?xml version="1.0"?>
 
 <model>


### PR DESCRIPTION
While working on some stuff for GazeboWorldDesigner, I noticed that IGVC's models folder wasn't exported to be available for other tools and the *.config files were not valid XML files.