### PR TITLE
Rosbag

### DIFF
--- a/igvc/launch/compressed_to_raw.launch
+++ b/igvc/launch/compressed_to_raw.launch
@@ -1,0 +1,5 @@
+<!-- converts compressed image to raw iamge -->
+
+<launch>
+    <node name="republish" type="republish" pkg="image_transport" output="screen" args="compressed in:=/usb_cam_center/image_raw raw out:=/usb_cam_center/image_raw" />
+</launch>

--- a/igvc/launch/rosbag.launch
+++ b/igvc/launch/rosbag.launch
@@ -4,12 +4,6 @@
     excluding some of the duplicate image_transport topics.
     -->
 <launch>
-    <node pkg="igvc" type="system_stats" name="system_stats" output="screen">
-        <param name="frequency" value="10"/>
-    </node>
-
     <node pkg="rosbag" type="record" name="record" output="screen"
-    args="-a -x '(.*)image(.*)*'" />
-    <node pkg="rosbag" type="record" name="record_image" output="screen"
-    args="-e '/usb_cam/image_raw'" />
+    args="-a -x '(.*)image(.*)*' /usb_cam_center/image_raw/compressed" />
 </launch>

--- a/igvc/launch/rosbag_sensors.launch
+++ b/igvc/launch/rosbag_sensors.launch
@@ -5,5 +5,5 @@
     -->
 <launch>
     <node pkg="rosbag" type="record" name="record" output="screen"
-    args="/battery /encoders /fix /gps/filtered /pc2 /scan/pointcloud /imu /joint_states /lights /motors /robot_enabled /tf /tf_static /usb_cam_center/camera_info /usb_cam_center/image_raw/compressed /vel /waypoint /time_reference" />
+    args="/battery /encoders /fix /pc2 /scan/pointcloud /imu /joint_states /lights /motors /robot_enabled /tf /tf_static /usb_cam_center/camera_info /usb_cam_center/image_raw/compressed /vel /waypoint /time_reference" />
 </launch>

--- a/igvc/launch/rosbag_sensors.launch
+++ b/igvc/launch/rosbag_sensors.launch
@@ -4,10 +4,6 @@
     excluding some of the duplicate image_transport topics.
     -->
 <launch>
-    <node pkg="igvc" type="system_stats" name="system_stats" output="screen">
-        <param name="frequency" value="10"/>
-    </node>
-
     <node pkg="rosbag" type="record" name="record" output="screen"
-    args="/battery /encoders /fix /gps_odom /scan /imu  /joint_states /lights /line_cloud /map /map_origin /motors /odom_combined /path_display /scan/pointcloud /robot_enabled /sick_tim551_2050001/parameter_descriptions /tf /tf_static /sick_tim551_2050001/parameter_updates /usb_cam_center/camera_info /usb_cam_center/image_raw /vel /waypoint /time_reference" />
+    args="/battery /encoders /fix /gps/filtered /pc2 /scan/pointcloud /imu /joint_states /lights /motors /robot_enabled /tf /tf_static /usb_cam_center/camera_info /usb_cam_center/image_raw/compressed /vel /waypoint /time_reference" />
 </launch>


### PR DESCRIPTION
Fixed the rosbag.launch in order to bag compressed images and all other topics. 

Changed rosbag_sensors.launch to include only the sensor published topics.

add a launch file to convert compressed to image raw for use when looking at bag files