### PR TITLE
Corrected name of launch file for pathing node

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ roslaunch igvc mapper.launch
 ```
 Next, run the following command to start our pathing node and navigate around the course autonomously
 ```
-roslaunch igvc path.launch
+roslaunch igvc pather.launch
 ```
 Alternatively, you can control the car manually with a USB gamepad with this command:
 ```


### PR DESCRIPTION
The second-to-last step of the Gazebo instructions in the readme for this repository says to run this command
```
roslaunch igvc path.launch
```
which doesn't work because `path.launch` is actually called `pather.launch` (located at igvc/launch/pather.launch).