### PR TITLE
Add warning message when distance to goal node is greater than a specified threshold.

### DIFF
--- a/igvc/launch/pather.launch
+++ b/igvc/launch/pather.launch
@@ -17,6 +17,8 @@
           <param name="point_turns_enabled" type="bool" value="false"/>
           <param name="reverse_enabled" type="bool" value="false"/>
           <param name="max_obstacle_delta_t" type="double" value="0.1"/>
+          <param name="max_goal_distance" type = "double" value = "60"/>
+          <param name="verbosity_threshold" type = "double" value = "40"/>
 
           <!-- distance in meters to flag point as valid without checking obstacles -->
           <!-- used for efficiency purposes -->


### PR DESCRIPTION
`max_goal_distance` [double] (maximum distance for which to perform a search) and
`verbosity_threshold` [double] (goal distance at which to output warning messages)

have been located in the parameter server under the `path_planner` namespace.

I think that relocating the previously hard-coded maximum distance to the parameter server helps speed up testing and can be easily modified without disturbing the source files.