### PR TITLE
added including chassis name and location to naming of the bag file

### DIFF
--- a/igvc_utils/launch/rosbag.launch
+++ b/igvc_utils/launch/rosbag.launch
@@ -1,3 +1,5 @@
+<?xml version="1.0"?>
+
 <!-- rosbag.launch -->
 <!--
     This file will launch the rosbag recorder and will log all topics
@@ -5,5 +7,5 @@
     -->
 <launch>
     <node pkg="rosbag" type="record" name="record" output="screen"
-    args="-a -x '(.*)image(.*)*' /usb_cam_center/image_raw/compressed" />
+          args="-a -x '(.*)image(.*)*' -e '(.*)/image_raw/compressed' -o $(env HOME)/data/$(env CHASSIS_NAME)_$(env LOCATION)" />
 </launch>


### PR DESCRIPTION
New convention for naming bag files. Will now prepend the chassis name along with the location. They will be set from environment variables. There will be a script created to set them properly later. names will come of the form

(chassis_name)_(location)_date-time 