### PR TITLE
OcTree based Occpancy Grid Mapping

### DIFF
--- a/igvc_navigation/CMakeLists.txt
+++ b/igvc_navigation/CMakeLists.txt
@@ -15,6 +15,8 @@ find_package(catkin REQUIRED COMPONENTS
   tf
   pcl_ros
   igvc_utils
+  octomap_ros
+  octomap_msgs
 )
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
@@ -23,6 +25,7 @@ find_package(OpenCV REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system)
 find_package(PCL REQUIRED filters)
+find_package(octomap REQUIRED)
 
 set(CMAKE_CXX_FLAGS "-g -std=c++11 -Wall ${CMAKE_CXX_FLAGS}")
 

--- a/igvc_navigation/launch/mapper.launch
+++ b/igvc_navigation/launch/mapper.launch
@@ -1,6 +1,4 @@
 <launch>
-    <include file="$(find igvc_navigation)/launch/localization.launch" />
-
     <!-- Map Node -->
     <node name="mapper" pkg="igvc_navigation" type="mapper" output="screen">
             <param name="topics" type="string" value="/scan/pointcloud /semantic_segmentation_cloud"/>
@@ -15,6 +13,7 @@
             <param name="start_Y" type="double" value="100"/>
             <param name="increment_step" type="int" value="125"/>
             <param name="debug" type="bool" value="true"/>
+            <rosparam command="load" file="$(find igvc_navigation)/launch/octomap.yaml"/>
     </node>
 
     <arg name="plot_rviz" default="false"/>

--- a/igvc_navigation/launch/mapper.launch
+++ b/igvc_navigation/launch/mapper.launch
@@ -1,18 +1,6 @@
 <launch>
     <!-- Map Node -->
     <node name="mapper" pkg="igvc_navigation" type="mapper" output="screen">
-            <param name="topics" type="string" value="/scan/pointcloud /semantic_segmentation_cloud"/>
-            <param name="occupancy_grid_length" type="int" value="200" />
-            <param name="occupancy_grid_width" type="int" value="200" />
-            <param name="occupancy_grid_resolution" type="double" value="0.2" />
-            <param name="occupancy_grid_threshold" type="int" value="178" />
-            <!-- Set decay_period to 0 to disable decay -->
-            <param name="decay_period" type="double" value="60" />
-            <param name="transform_max_wait_time" type="double" value="0.5" />
-            <param name="start_X" type="double" value="100"/>
-            <param name="start_Y" type="double" value="100"/>
-            <param name="increment_step" type="int" value="125"/>
-            <param name="debug" type="bool" value="true"/>
             <rosparam command="load" file="$(find igvc_navigation)/launch/octomap.yaml"/>
     </node>
 

--- a/igvc_navigation/launch/octomap.yaml
+++ b/igvc_navigation/launch/octomap.yaml
@@ -24,12 +24,14 @@ ground_filter:
 map:
   # In units of meters, not cells
   # width of grid = width / resolution
-  length_x: 200
-  width_y: 200
   length: 200
   width: 200
   start_x: 100
   start_y: 100
   encoding: "CV_8UC1"
   log_odds_default: 0
+node:
+  lidar_topic: "/scan/pointcloud"
+  transform_max_wait_time: 0.5
+  debug: true
 map_floor_threshold: 0.5

--- a/igvc_navigation/launch/octomap.yaml
+++ b/igvc_navigation/launch/octomap.yaml
@@ -18,8 +18,8 @@ filter:
   filter_angle: 2
   distance: 3
 blur:
-  kernel_size: 5
-  std_dev: 5
+  kernel_size: 17
+  std_dev: 11
 ground_filter:
   enable: false
   iterations: 200

--- a/igvc_navigation/launch/octomap.yaml
+++ b/igvc_navigation/launch/octomap.yaml
@@ -31,5 +31,5 @@ map:
   start_x: 100
   start_y: 100
   encoding: "CV_8UC1"
-  log_odds_default: 0map_floor_
+  log_odds_default: 0
 map_floor_threshold: 0.5

--- a/igvc_navigation/launch/octomap.yaml
+++ b/igvc_navigation/launch/octomap.yaml
@@ -3,13 +3,20 @@ octree:
   lazy_evaluation: false
 sensor_model:
   hit: 0.8
-  miss: 0.4
+  miss: 0.3
+  miss_empty: 0.49
   min: 0.03
   max: 0.97
-  max_range: 30
+  max_range: 50
+  angular_resolution: 0.01
+  lidar_miss_cast_distance: 15
+#  lidar_angle_start: -2
+#  lidar_angle_end: 2
+  lidar_angle_start: -0.5
+  lidar_angle_end: 0.5
 filter:
-  min_distance: 2
-  max_distance: 40
+  filter_angle: 2
+  distance: 3
 ground_filter:
   enable: false
   iterations: 200
@@ -26,7 +33,8 @@ map:
   encoding: "CV_8UC1"
   log_odds_default: 0
 node:
+#  lidar_topic: "/scan/pointcloud"
   lidar_topic: "/scan/pointcloud"
-  transform_max_wait_time: 0.5
+  transform_max_wait_time: 1
   debug: true
 map_floor_threshold: 0.5

--- a/igvc_navigation/launch/octomap.yaml
+++ b/igvc_navigation/launch/octomap.yaml
@@ -31,5 +31,5 @@ map:
   start_x: 100
   start_y: 100
   encoding: "CV_8UC1"
-  log_odds_default: 0
-
+  log_odds_default: 0map_floor_
+map_floor_threshold: 0.5

--- a/igvc_navigation/launch/octomap.yaml
+++ b/igvc_navigation/launch/octomap.yaml
@@ -7,11 +7,6 @@ sensor_model:
   min: 0.03
   max: 0.97
   max_range: 30
-  mismatch_penalty: 5
-  empty_coeff: 0.000001
-  occupied_coeff: 1
-  free_coeff: 1
-  algorithm_number: 4
 filter:
   min_distance: 2
   max_distance: 40

--- a/igvc_navigation/launch/octomap.yaml
+++ b/igvc_navigation/launch/octomap.yaml
@@ -17,6 +17,9 @@ sensor_model:
 filter:
   filter_angle: 2
   distance: 3
+blur:
+  kernel_size: 5
+  std_dev: 5
 ground_filter:
   enable: false
   iterations: 200

--- a/igvc_navigation/launch/octomap.yaml
+++ b/igvc_navigation/launch/octomap.yaml
@@ -1,5 +1,5 @@
 octree:
-  resolution: 0.1
+  resolution: 0.2
   lazy_evaluation: false
 sensor_model:
   hit: 0.8

--- a/igvc_navigation/launch/octomap.yaml
+++ b/igvc_navigation/launch/octomap.yaml
@@ -1,0 +1,35 @@
+octree:
+  resolution: 0.1
+  lazy_evaluation: false
+sensor_model:
+  hit: 0.8
+  miss: 0.4
+  min: 0.03
+  max: 0.97
+  max_range: 30
+  mismatch_penalty: 5
+  empty_coeff: 0.000001
+  occupied_coeff: 1
+  free_coeff: 1
+  algorithm_number: 4
+filter:
+  min_distance: 2
+  max_distance: 40
+ground_filter:
+  enable: false
+  iterations: 200
+  distance_threshold: 0.05
+  eps_angle: 0.15
+  plane_distance: 0.04
+map:
+  # In units of meters, not cells
+  # width of grid = width / resolution
+  length_x: 200
+  width_y: 200
+  length: 200
+  width: 200
+  start_x: 100
+  start_y: 100
+  encoding: "CV_8UC1"
+  log_odds_default: 0
+

--- a/igvc_navigation/package.xml
+++ b/igvc_navigation/package.xml
@@ -47,6 +47,8 @@
   <build_depend>pluginlib</build_depend>
   <build_depend>class_loader</build_depend>
   <build_depend>image_geometry</build_depend>
+  <build_depend>octomap</build_depend>
+  <build_depend>octomap_ros</build_depend>
 
   <!-- Run dependencies -->
   <run_depend>roscpp</run_depend>
@@ -63,6 +65,8 @@
   <run_depend>laser_geometry</run_depend>
   <run_depend>nmea_navsat_driver</run_depend>
   <run_depend>gps_common</run_depend>
+  <run_depend>octomap</run_depend>
+  <run_depend>octomap_ros</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/igvc_navigation/src/mapper/CMakeLists.txt
+++ b/igvc_navigation/src/mapper/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_executable(mapper main.cpp)
+add_executable(mapper main.cpp octomapper.cpp octomapper.h)
 add_dependencies(mapper igvc_msgs_gencpp)
-target_link_libraries(mapper ${catkin_LIBRARIES} ${PCL_LIBRARIES})
+target_link_libraries(mapper ${catkin_LIBRARIES} ${PCL_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES})

--- a/igvc_navigation/src/mapper/CMakeLists.txt
+++ b/igvc_navigation/src/mapper/CMakeLists.txt
@@ -1,3 +1,8 @@
+find_package(OpenMP)
+if (OpenMP_FOUND)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+endif ()
 add_executable(mapper main.cpp octomapper.cpp octomapper.h)
 add_dependencies(mapper igvc_msgs_gencpp)
 target_link_libraries(mapper ${catkin_LIBRARIES} ${PCL_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES})

--- a/igvc_navigation/src/mapper/main.cpp
+++ b/igvc_navigation/src/mapper/main.cpp
@@ -10,64 +10,128 @@
 #include <ros/publisher.h>
 #include <ros/ros.h>
 #include <sensor_msgs/Image.h>
+#include <signal.h>
 #include <stdlib.h>
+#include <tf/transform_datatypes.h>
+#include <tf_conversions/tf_eigen.h>
+#include <visualization_msgs/Marker.h>
 #include <Eigen/Core>
 #include <igvc_utils/NodeUtils.hpp>
 #include <igvc_utils/RobotState.hpp>
 #include <opencv2/core/eigen.hpp>
 #include <opencv2/opencv.hpp>
-#include <tf/transform_datatypes.h>
-#include <tf_conversions/tf_eigen.h>
 #include "octomapper.h"
-#include <visualization_msgs/Marker.h>
-#include <signal.h>
 
-cv_bridge::CvImage img_bridge;
+class Mapper
+{
+public:
+  Mapper();
 
-ros::Publisher map_pub;                  // Publishes map
-ros::Publisher debug_pub;                // Debug version of above
-ros::Publisher debug_pcl_pub;            // Publishes map as individual PCL points
-ros::Publisher ground_pub;            // Publishes map as individual PCL points
-ros::Publisher nonground_pub;            // Publishes map as individual PCL points
-ros::Publisher sensor_pub;            // Publishes map as individual PCL points
-std::unique_ptr<cv::Mat> published_map;  // matrix will be publishing
-std::map<std::string, tf::StampedTransform> transforms;
-std::unique_ptr<tf::TransformListener> tf_listener;
+private:
+  void pc_callback(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &pc);
+  void publish(const cv::Mat &map, uint64_t stamp);
+  void setMessageMetadata(igvc_msgs::map &message, sensor_msgs::Image &image, uint64_t pcl_stamp);
+  bool checkExistsStaticTransform(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &msg, const std::string &topic);
+  bool getOdomTransform(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &msg);
 
-double resolution;
-double transform_max_wait_time;
-int start_x;  // start x location
-int start_y;  // start y location
-int length_y;
-int width_x;
-bool debug;
-double radius;
-RobotState state;
-RobotState state2;
+  cv_bridge::CvImage m_img_bridge;
 
-std::unique_ptr<Octomapper> octomapper;
-pc_map_pair pc_map_pair;
+  ros::Publisher m_map_pub;                                  // Publishes map
+  ros::Publisher m_debug_pub;                                // Debug version of above
+  ros::Publisher m_debug_pcl_pub;                            // Publishes map as individual PCL points
+  ros::Publisher m_ground_pub;                               // Publishes ground points
+  ros::Publisher m_nonground_pub;                            // Publishes non ground points
+  ros::Publisher m_sensor_pub;                               // Publishes lidar position
+  std::unique_ptr<cv::Mat> m_published_map;                  // Matrix will be publishing
+  std::map<std::string, tf::StampedTransform> m_transforms;  // Map of static transforms TODO: Refactor this
+  std::unique_ptr<tf::TransformListener> m_tf_listener;      // TF Listener
+
+  double m_resolution;
+  double m_transform_max_wait_time;
+  int m_start_x;   // start x (m)
+  int m_start_y;   // start y (m)
+  int m_length_x;  // length (m)
+  int m_width_y;   // width (m)
+  bool m_debug;
+  double m_radius;  // Radius to filter lidar points // TODO: Refactor to a new node
+  std::string m_lidar_topic;
+  RobotState m_state;          // Odom -> Base_link
+  RobotState m_odom_to_lidar;  // Odom -> Lidar
+
+  std::unique_ptr<Octomapper> m_octomapper;
+  pc_map_pair m_pc_map_pair;  // Struct storing both the octomap and the cv::Mat map
+};
+
+Mapper::Mapper() : m_tf_listener{ std::unique_ptr<tf::TransformListener>(new tf::TransformListener()) }
+{
+  ros::NodeHandle nh;
+  ros::NodeHandle pNh("~");
+
+  igvc::getParam(pNh, "octree/resolution", m_resolution);
+  igvc::getParam(pNh, "map/length", m_length_x);
+  igvc::getParam(pNh, "map/width", m_width_y);
+  igvc::getParam(pNh, "map/start_x", m_start_x);
+  igvc::getParam(pNh, "map/start_y", m_start_y);
+  igvc::getParam(pNh, "node/debug", m_debug);
+  igvc::getParam(pNh, "sensor_model/max_range", m_radius);
+  igvc::getParam(pNh, "node/lidar_topic", m_lidar_topic);
+
+  m_octomapper = std::unique_ptr<Octomapper>(new Octomapper(pNh));
+  m_octomapper->create_octree(m_pc_map_pair);
+
+  ros::Subscriber pcl_sub = nh.subscribe<pcl::PointCloud<pcl::PointXYZ>>(m_lidar_topic, 1, &Mapper::pc_callback, this);
+
+  m_published_map = std::unique_ptr<cv::Mat>(new cv::Mat(m_length_x, m_width_y, CV_8UC1));
+
+  m_map_pub = nh.advertise<igvc_msgs::map>("/map", 1);
+
+  if (m_debug)
+  {
+    m_debug_pub = nh.advertise<sensor_msgs::Image>("/map_debug", 1);
+    m_debug_pcl_pub = nh.advertise<pcl::PointCloud<pcl::PointXYZRGB>>("/map_debug_pcl", 1);
+    m_ground_pub = nh.advertise<pcl::PointCloud<pcl::PointXYZ>>("/ground_pcl", 1);
+    m_nonground_pub = nh.advertise<pcl::PointCloud<pcl::PointXYZ>>("/nonground_pcl", 1);
+    m_sensor_pub = nh.advertise<visualization_msgs::Marker>("/sensor_pos", 1);
+  }
+
+  ros::spin();
+}
 
 /**
  * Updates <code>RobotState state</code> with the latest tf transform using the timestamp of the message passed in
- * @param msg <code>pcl::PointCloud</code> message with the timestamp used for looking up the tf transform
+ * @param[in] msg <code>pcl::PointCloud</code> message with the timestamp used for looking up the tf transform
  */
-void getOdomTransform(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &msg) {
+bool Mapper::getOdomTransform(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &msg)
+{
   tf::StampedTransform transform;
   tf::StampedTransform transform2;
   ros::Time messageTimeStamp;
   pcl_conversions::fromPCL(msg->header.stamp, messageTimeStamp);
-  if (tf_listener->waitForTransform("/odom", "/base_link", messageTimeStamp, ros::Duration(transform_max_wait_time))) {
-    tf_listener->lookupTransform("/odom", "/base_link", messageTimeStamp, transform);
-    state.setState(transform);
-    tf_listener->lookupTransform("/odom", "/lidar", messageTimeStamp, transform2);
-    state2.setState(transform2);
-  } else {
-    ROS_DEBUG("Failed to get transform from /base_link to /odom in time, using newest transforms");
-    tf_listener->lookupTransform("/odom", "/base_link", ros::Time(0), transform);
-    state.setState(transform);
-    tf_listener->lookupTransform("/odom", "/lidar", ros::Time(0), transform2);
-    state2.setState(transform2);
+  try
+  {
+    if (m_tf_listener->waitForTransform("/odom", "/base_link", messageTimeStamp,
+                                        ros::Duration(m_transform_max_wait_time)))
+    {
+      m_tf_listener->lookupTransform("/odom", "/base_link", messageTimeStamp, transform);
+      m_state.setState(transform);
+      m_tf_listener->lookupTransform("/odom", "/lidar", messageTimeStamp, transform2);
+      m_odom_to_lidar.setState(transform2);
+      return true;
+    }
+    else
+    {
+      ROS_DEBUG("Failed to get transform from /base_link to /odom in time, using newest transforms");
+      m_tf_listener->lookupTransform("/odom", "/base_link", ros::Time(0), transform);
+      m_state.setState(transform);
+      m_tf_listener->lookupTransform("/odom", "/lidar", ros::Time(0), transform2);
+      m_odom_to_lidar.setState(transform2);
+      return true;
+    }
+  }
+  catch (const tf::TransformException &ex)
+  {
+    ROS_ERROR("%s", ex.what());
+    return false;
   }
 }
 
@@ -75,42 +139,48 @@ void getOdomTransform(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &msg) {
 /**
  * Populates <code>igvc_msgs::map message</code> with information from <code>sensor_msgs::Image</code> and the
  * timestamp from <code>pcl_stamp</code>
- * @param message message to be filled out
- * @param image image containing map data to be put into <code>message</code>
- * @param pcl_stamp time stamp from the pcl to be used for <code>message</code>
+ * @param[out] message message to be filled out
+ * @param[in] image image containing map data to be put into <code>message</code>
+ * @param[in] pcl_stamp time stamp from the pcl to be used for <code>message</code>
  */
-void setMsgValues(igvc_msgs::map &message, sensor_msgs::Image &image, uint64_t pcl_stamp) {
+void Mapper::setMessageMetadata(igvc_msgs::map &message, sensor_msgs::Image &image, uint64_t pcl_stamp)
+{
   pcl_conversions::fromPCL(pcl_stamp, image.header.stamp);
   pcl_conversions::fromPCL(pcl_stamp, message.header.stamp);
   message.header.frame_id = "/odom";
   message.image = image;
-  message.length = length_y / resolution;
-  message.width = width_x / resolution;
-  message.resolution = resolution;
-  message.orientation = state.yaw();
-  message.x = std::round(state.x() / resolution) + start_x/resolution;
-  message.y = std::round(state.y() / resolution) + start_y/resolution;
-  message.x_initial = start_x / resolution;
-  message.y_initial = start_y / resolution;
+  message.length = m_length_x / m_resolution;
+  message.width = m_width_y / m_resolution;
+  message.resolution = m_resolution;
+  message.orientation = m_state.yaw();
+  message.x = std::round(m_state.x() / m_resolution) + m_start_x / m_resolution;
+  message.y = std::round(m_state.y() / m_resolution) + m_start_y / m_resolution;
+  message.x_initial = m_start_x / m_resolution;
+  message.y_initial = m_start_y / m_resolution;
 }
 
 /**
  * Checks if transform from base_footprint to msg.header.frame_id exists
- * @param msg
- * @param topic
+ * @param[in] msg
+ * @param[in] topic Topic to check for
  */
-bool checkExistsStaticTransform(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &msg, const std::string &topic) {
-  if (transforms.find(topic) == transforms.end()) {
+bool Mapper::checkExistsStaticTransform(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &msg, const std::string &topic)
+{
+  if (m_transforms.find(topic) == m_transforms.end())
+  {
     // Wait for transform between frame_id (ex. /scan/pointcloud) and base_footprint.
     ros::Time messageTimeStamp;
     pcl_conversions::fromPCL(msg->header.stamp, messageTimeStamp);
     ROS_INFO_STREAM("Getting transform for " << topic << " from " << msg->header.frame_id << " to /base_footprint \n");
-    if (tf_listener->waitForTransform("/base_footprint", msg->header.frame_id, messageTimeStamp, ros::Duration(3.0))) {
+    if (m_tf_listener->waitForTransform("/base_footprint", msg->header.frame_id, messageTimeStamp, ros::Duration(3.0)))
+    {
       tf::StampedTransform transform;
-      tf_listener->lookupTransform("/base_footprint", msg->header.frame_id, messageTimeStamp, transform);
-      transforms.insert(std::pair<std::string, tf::StampedTransform>(topic, transform));
-      ROS_INFO_STREAM("Found transform!");
-    } else {
+      m_tf_listener->lookupTransform("/base_footprint", msg->header.frame_id, messageTimeStamp, transform);
+      m_transforms.insert(std::pair<std::string, tf::StampedTransform>(topic, transform));
+      ROS_INFO_STREAM("Found static transform from " << msg->header.frame_id << " to /base_footprint");
+    }
+    else
+    {
       ROS_ERROR_STREAM("Failed to find transform using empty transform");
       return false;
     }
@@ -120,71 +190,74 @@ bool checkExistsStaticTransform(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &
 
 /**
  * Publishes the given map at the given stamp
- * @param map map to be published
- * @param stamp pcl stamp of the timestamp to be used
+ * @param[in] map map to be published
+ * @param[in] stamp pcl stamp of the timestamp to be used
  */
-void publish(const cv::Mat &map, uint64_t stamp) {
+void Mapper::publish(const cv::Mat &map, uint64_t stamp)
+{
   igvc_msgs::map message;    // >> message to be sent
   sensor_msgs::Image image;  // >> image in the message
-  img_bridge = cv_bridge::CvImage(message.header, sensor_msgs::image_encodings::MONO8, map);
-  img_bridge.toImageMsg(image);  // from cv_bridge to sensor_msgs::Image
+  m_img_bridge = cv_bridge::CvImage(message.header, sensor_msgs::image_encodings::MONO8, map);
+  m_img_bridge.toImageMsg(image);  // from cv_bridge to sensor_msgs::Image
 
-  setMsgValues(message, image, stamp);
-  map_pub.publish(message);
-  if (debug) {
-    debug_pub.publish(image);
+  setMessageMetadata(message, image, stamp);
+  m_map_pub.publish(message);
+  if (m_debug)
+  {
+    m_debug_pub.publish(image);
     // ROS_INFO_STREAM("\nThe robot is located at " << state);
-    pcl::PointCloud<pcl::PointXYZRGB>::Ptr fromOcuGrid =
-        boost::make_shared<pcl::PointCloud<pcl::PointXYZRGB>>();
-    for (int i = 0; i < width_x/resolution; i++) {
-      for (int j = 0; j < length_y/resolution; j++) {
+    pcl::PointCloud<pcl::PointXYZRGB>::Ptr fromOcuGrid = boost::make_shared<pcl::PointCloud<pcl::PointXYZRGB>>();
+    for (int i = 0; i < m_length_x / m_resolution; i++)
+    {
+      for (int j = 0; j < m_width_y / m_resolution; j++)
+      {
         pcl::PointXYZRGB p;
         uchar prob = map.at<uchar>(i, j);
-        if (prob > 127) {
-          p = pcl::PointXYZRGB();
-          p.x = (i * resolution) - (width_x / 2);
-          p.y = (j * resolution) - (length_y / 2);
+        p = pcl::PointXYZRGB();
+        p.x = (i * m_resolution) - (m_width_y / 2);
+        p.y = (j * m_resolution) - (m_length_x / 2);
+        if (prob > 127)
+        {
           p.r = 0;
           p.g = static_cast<uint8_t>((prob - 127) * 2);
           p.b = 0;
           fromOcuGrid->points.push_back(p);
-          //          ROS_INFO_STREAM("(" << i << ", " << j << ") -> (" << p.x << ", " << p.y << ")");
-        } else if (prob < 127) {
+        }
+        else if (prob < 127)
+        {
           p = pcl::PointXYZRGB();
-          p.x = (i * resolution) - (width_x / 2);
-          p.y = (j * resolution) - (length_y / 2);
           p.r = 0;
           p.g = 0;
           p.b = static_cast<uint8_t>((127 - prob) * 2);
           fromOcuGrid->points.push_back(p);
-          //          ROS_INFO_STREAM("(" << i << ", " << j << ") -> (" << p.x << ", " << p.y << ")");
-        } else if (prob == 127) {
         }
-        // Set x y coordinates as the center of the grid cell.
       }
     }
     fromOcuGrid->header.frame_id = "/odom";
     fromOcuGrid->header.stamp = stamp;
-    //    ROS_INFO_STREAM("Size: " << fromOcuGrid->points.size() << " / " << (width_x * length_y));
-    debug_pcl_pub.publish(fromOcuGrid);
+    m_debug_pcl_pub.publish(fromOcuGrid);
   }
 }
 
 /**
  * Callback for pointcloud. Filters the lidar scan, then inserts it into the octree.
- * @param pc lidar scan
+ * @param[in] pc Lidar scan
  */
-void pc_callback(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &pc) {
+void Mapper::pc_callback(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &pc)
+{
   // Pass through filter to only keep ones closest to us
   pcl::PointCloud<pcl::PointXYZ>::Ptr small(new pcl::PointCloud<pcl::PointXYZ>);
   float dist;
-  for (int point_i = 0; point_i < pc->size(); ++point_i) {
-    dist = pc->at(point_i).x * pc->at(point_i).x + pc->at(point_i).y * pc->at(point_i).y + pc->at(point_i).z * pc->at(point_i).z;
-    if (dist <= radius*radius*radius) {
+  for (int point_i = 0; point_i < pc->size(); ++point_i)
+  {
+    dist = pc->at(point_i).x * pc->at(point_i).x + pc->at(point_i).y * pc->at(point_i).y +
+           pc->at(point_i).z * pc->at(point_i).z;
+    if (dist <= m_radius * m_radius * m_radius)
+    {
       small->push_back(pc->at(point_i));
     }
   }
-  //  ROS_INFO("Got Pointcloud");
+
   // make transformed clouds
   pcl::PointCloud<pcl::PointXYZ>::Ptr transformed =
       pcl::PointCloud<pcl::PointXYZ>::Ptr(new pcl::PointCloud<pcl::PointXYZ>());
@@ -198,18 +271,23 @@ void pc_callback(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &pc) {
   }
 
   // Lookup transform form Ros Localization for position
-  getOdomTransform(pc);
+  if (!getOdomTransform(pc))
+  {
+    ROS_ERROR("Sleeping 2 seconds then trying again...");
+    ros::Duration(2).sleep();
+    return;
+  }
 
   // Apply transformation from lidar to base_link aka robot pose
-  pcl_ros::transformPointCloud(*small, *transformed, transforms.at("/scan/pointcloud"));
-  pcl_ros::transformPointCloud(*transformed, *transformed, state.transform);
+  pcl_ros::transformPointCloud(*small, *transformed, m_transforms.at(m_lidar_topic));
+  pcl_ros::transformPointCloud(*transformed, *transformed, m_state.transform);
 
   visualization_msgs::Marker points;
   points.header.frame_id = "/odom";
   points.header.stamp = ros::Time::now();
-  points.pose.position.x = state2.transform.getOrigin().getX();
-  points.pose.position.y = state2.transform.getOrigin().getY();
-  points.pose.position.z = state2.transform.getOrigin().getZ();
+  points.pose.position.x = m_odom_to_lidar.transform.getOrigin().getX();
+  points.pose.position.y = m_odom_to_lidar.transform.getOrigin().getY();
+  points.pose.position.z = m_odom_to_lidar.transform.getOrigin().getZ();
 
   points.action = visualization_msgs::Marker::ADD;
   points.id = 0;
@@ -220,68 +298,17 @@ void pc_callback(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &pc) {
   points.color.g = 1.0f;
   points.color.a = 1.0;
 
-  sensor_pub.publish(points);
+  m_sensor_pub.publish(points);
 
-  octomapper->insert_scan(state2.transform.getOrigin(), pc_map_pair, *transformed);
+  m_octomapper->insert_scan(m_odom_to_lidar.transform.getOrigin(), m_pc_map_pair, *transformed);
 
-  //  ROS_INFO("Publishing");
   // Publish map
-  //  ROS_INFO_STREAM("octomap tree size1: " << pc_map_pair.octree->getNumLeafNodes());
-  octomapper->get_updated_map(pc_map_pair);
-  //  ROS_INFO_STREAM("octomap tree size2: " << pc_map_pair.octree->getNumLeafNodes());
-  publish(*(pc_map_pair.map), pc->header.stamp);
+  m_octomapper->get_updated_map(m_pc_map_pair);
+  publish(*(m_pc_map_pair.map), pc->header.stamp);
 }
 
-/**
- * Cleanup method to release resouces held
- * @param sig
- */
-void node_cleanup(int sig)
+int main(int argc, char **argv)
 {
-  published_map.reset();
-  published_map.reset();
-  octomapper.reset();
-  tf_listener.reset();
-  ros::shutdown();
-}
-
-int main(int argc, char **argv) {
   ros::init(argc, argv, "mapper");
-  ros::NodeHandle nh;
-  ros::NodeHandle pNh("~");
-  std::string topics;
-
-  signal(SIGINT, node_cleanup);
-
-  std::list<ros::Subscriber> subs;
-  tf_listener = std::unique_ptr<tf::TransformListener>(new tf::TransformListener());
-
-  octomapper = std::unique_ptr<Octomapper>(new Octomapper(pNh));
-  octomapper->create_octree(pc_map_pair);
-
-  // assumes all params inputted in meters
-  igvc::getParam(pNh, "octree/resolution", resolution);
-  igvc::getParam(pNh, "map/length", length_y);
-  igvc::getParam(pNh, "map/width", width_x);
-  igvc::getParam(pNh, "map/start_x", start_x);
-  igvc::getParam(pNh, "map/start_y", start_y);
-  igvc::getParam(pNh, "debug", debug);
-  igvc::getParam(pNh, "sensor_model/max_range", radius);
-
-  // convert from meters to grid
-  ros::Subscriber pcl_sub = nh.subscribe<pcl::PointCloud<pcl::PointXYZ>>("/scan/pointcloud", 1, &pc_callback);
-
-  published_map = std::unique_ptr<cv::Mat>(new cv::Mat(length_y, width_x, CV_8UC1));
-
-  map_pub = nh.advertise<igvc_msgs::map>("/map", 1);
-
-  if (debug) {
-    debug_pub = nh.advertise<sensor_msgs::Image>("/map_debug", 1);
-    debug_pcl_pub = nh.advertise<pcl::PointCloud<pcl::PointXYZRGB>>("/map_debug_pcl", 1);
-    ground_pub = nh.advertise<pcl::PointCloud<pcl::PointXYZ>>("/ground_pcl", 1);
-    nonground_pub = nh.advertise<pcl::PointCloud<pcl::PointXYZ>>("/nonground_pcl", 1);
-    sensor_pub = nh.advertise<visualization_msgs::Marker>("/sensor_pos", 1);
-  }
-
-  ros::spin();
+  Mapper mapper;
 }

--- a/igvc_navigation/src/mapper/main.cpp
+++ b/igvc_navigation/src/mapper/main.cpp
@@ -107,6 +107,12 @@ void checkExistsStaticTransform(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &
     }
   }
 }
+
+/**
+ * Publishes the given map at the given stamp
+ * @param map map to be published
+ * @param stamp pcl stamp of the timestamp to be used
+ */
 void publish(const cv::Mat &map, uint64_t stamp) {
   igvc_msgs::map message;    // >> message to be sent
   sensor_msgs::Image image;  // >> image in the message
@@ -154,15 +160,17 @@ void publish(const cv::Mat &map, uint64_t stamp) {
   }
 }
 
+/**
+ * Callback for pointcloud. Filters the lidar scan, then inserts it into the octree.
+ * @param pc lidar scan
+ */
 void pc_callback(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &pc) {
   // Pass through filter to only keep ones closest to us
   pcl::PointCloud<pcl::PointXYZ>::Ptr small(new pcl::PointCloud<pcl::PointXYZ>);
-  float distanceFromSphereCenterPoint;
-  bool pointIsWithinSphere;
+  float dist;
   for (int point_i = 0; point_i < pc->size(); ++point_i) {
-    distanceFromSphereCenterPoint = pc->at(point_i).x * pc->at(point_i).x + pc->at(point_i).y * pc->at(point_i).y + pc->at(point_i).z * pc->at(point_i).z;
-    pointIsWithinSphere = distanceFromSphereCenterPoint <= radius*radius*radius;
-    if (pointIsWithinSphere) {
+    dist = pc->at(point_i).x * pc->at(point_i).x + pc->at(point_i).y * pc->at(point_i).y + pc->at(point_i).z * pc->at(point_i).z;
+    if (dist <= radius*radius*radius) {
       small->push_back(pc->at(point_i));
     }
   }
@@ -234,6 +242,10 @@ void pc_callback(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &pc) {
   publish(*(pc_map_pair.map), pc->header.stamp);
 }
 
+/**
+ * Cleanup method to release resouces held
+ * @param sig
+ */
 void node_cleanup(int sig)
 {
   published_map.reset();

--- a/igvc_navigation/src/mapper/main.cpp
+++ b/igvc_navigation/src/mapper/main.cpp
@@ -63,7 +63,7 @@ void getOdomTransform(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &msg) {
     tf_listener->lookupTransform("/odom", "/lidar", messageTimeStamp, transform2);
     state2.setState(transform2);
   } else {
-    ROS_ERROR("Failed to get transform from /base_link to /odom in time, using newest transforms");
+    ROS_DEBUG("Failed to get transform from /base_link to /odom in time, using newest transforms");
     tf_listener->lookupTransform("/odom", "/base_link", ros::Time(0), transform);
     state.setState(transform);
     tf_listener->lookupTransform("/odom", "/lidar", ros::Time(0), transform2);

--- a/igvc_navigation/src/mapper/octomapper.cpp
+++ b/igvc_navigation/src/mapper/octomapper.cpp
@@ -1,0 +1,273 @@
+#include "octomapper.h"
+
+#include <octomap/octomap.h>
+#include <octomap_ros/conversions.h>
+
+// TODO: How to convert OcTree to occupancy grid?
+Octomapper::Octomapper(ros::NodeHandle pNh) {
+  igvc::getParam(pNh, "octree/resolution", m_octree_resolution);
+  igvc::getParam(pNh, "sensor_model/hit", m_prob_hit);
+  igvc::getParam(pNh, "sensor_model/miss", m_prob_miss);
+  igvc::getParam(pNh, "sensor_model/min", m_thresh_min);
+  igvc::getParam(pNh, "sensor_model/max", m_thresh_max);
+  igvc::getParam(pNh, "sensor_model/max_range", m_max_range);
+  igvc::getParam(pNh, "ground_filter/iterations", m_ransac_iterations);
+  igvc::getParam(pNh, "ground_filter/distance_threshold", m_ransac_distance_threshold);
+  igvc::getParam(pNh, "ground_filter/eps_angle", m_ransac_eps_angle);
+  igvc::getParam(pNh, "ground_filter/plane_distance", m_ground_filter_plane_dist);
+  igvc::getParam(pNh, "map/length", m_map_length);
+  igvc::getParam(pNh, "map/width", m_map_width);
+  igvc::getParam(pNh, "map/log_odds_default", m_odds_sum_default);
+  std::string map_encoding;
+  igvc::getParam(pNh, "map/encoding", map_encoding);
+  if (map_encoding == "CV_8UC1") {
+    m_map_encoding = CV_8UC1;
+  } else {
+    m_map_encoding = CV_8UC1;
+  }
+}
+
+void Octomapper::create_octree(pc_map_pair &pair) const {
+  pair.octree = boost::make_shared<octomap::OcTree>(m_octree_resolution);
+  pair.octree->setProbHit(m_prob_hit);
+  pair.octree->setProbMiss(m_prob_miss);
+  pair.octree->setClampingThresMin(m_thresh_min);
+  pair.octree->setClampingThresMax(m_thresh_max);
+  pair.octree->enableChangeDetection(true);
+  octomap::point3d min(-m_map_length / 2, -m_map_width / 2, -1);
+  octomap::point3d max(m_map_length / 2, m_map_width / 2, -1);
+  pair.octree->setBBXMin(min);
+  pair.octree->setBBXMax(max);
+}
+
+void PCL_to_Octomap(const pcl::PointCloud<pcl::PointXYZ> &pcl, octomap::Pointcloud &octo) {
+  sensor_msgs::PointCloud2 pc2;
+  pcl::toROSMsg(pcl, pc2);
+  octomap::pointCloud2ToOctomap(pc2, octo);
+}
+
+uchar toCharProb(float p) {
+  return static_cast<uchar>(p * 255);
+}
+
+float fromLogOdds(float log_odds) {
+  return 1 - (1 / (1 + exp(log_odds)));
+}
+
+std::string key_to_string(octomap::OcTreeKey key) {
+  std::ostringstream out;
+  out << std::hex << "(" << key.k[0] << ", " << key.k[1] << ", " << key[2] << ")";
+  return out.str();
+}
+
+void Octomapper::get_updated_map(struct pc_map_pair &pc_map_pair) const {
+  if (pc_map_pair.map == nullptr) {
+    create_map(pc_map_pair);
+  }
+  // TODO: Think about how to serialize / deserialize efficiently maybe?
+  // for (auto it = pc_map_pair.octree->changedKeysBegin(); it != pc_map_pair.octree->changedKeysEnd(); ++it)
+  //{
+  //  // TODO: Do we want the lowest depth here?
+  //  octomap::OcTreeNode* node = pc_map_pair.octree->search(it->first, 0);
+  //  auto coord = pc_map_pair.octree->keyToCoord(it->first);
+  //  int x = coord.x() * m_octree_resolution;
+  //  int y = coord.y() * m_octree_resolution;
+  //}
+
+  // Traverse entire tree
+  double minX, minY, minZ, maxX, maxY, maxZ;
+  pc_map_pair.octree->getMetricMin(minX, minY, minZ);
+  pc_map_pair.octree->getMetricMax(maxX, maxY, maxZ);
+
+  octomap::point3d minPt(minX, minY, minZ);
+  octomap::point3d maxPt(maxX, maxY, maxZ);
+//  ROS_INFO_STREAM("Min: " << minPt << ", Max: " << maxPt);
+
+  octomap::OcTreeKey minKey = pc_map_pair.octree->coordToKey(minPt);
+  octomap::OcTreeKey maxKey = pc_map_pair.octree->coordToKey(maxPt);
+  minX = std::min(minX, -0.5 * m_map_length);
+  maxX = std::max(maxX, 0.5 * m_map_length);
+  minY = std::min(minY, -0.5 * m_map_width);
+  maxY = std::max(maxY, 0.5 * m_map_width);
+  minPt = octomap::point3d(minX, minY, minZ);
+  maxPt = octomap::point3d(maxX, maxY, maxZ);
+
+  octomap::OcTreeKey padded_min_key, padded_max_key;
+  int depth = pc_map_pair.octree->getTreeDepth();
+  if (!pc_map_pair.octree->coordToKeyChecked(minPt, depth, padded_min_key)) {
+    ROS_ERROR_STREAM("Could not create padded min OcTree key at " << minPt);
+  }
+  if (!pc_map_pair.octree->coordToKeyChecked(maxPt, depth, padded_max_key)) {
+    ROS_ERROR_STREAM("Could not create padded max OcTree key at " << maxPt);
+  }
+
+//  ROS_INFO_STREAM("Min: " << minPt << ", Max: " << maxPt);
+//  ROS_INFO_STREAM("MinKey: " << key_to_string(minKey) << ", Max: " << key_to_string(maxKey));
+  std::vector<std::vector<float>> odds_sum(m_map_length / m_octree_resolution,
+                                           std::vector<float>(m_map_width / m_octree_resolution,
+                                                              m_odds_sum_default));  // TODO: Are these the right
+  for (octomap::OcTree::iterator it = pc_map_pair.octree->begin(), end = pc_map_pair.octree->end(); it != end; ++it) {
+    // If this is a leaf at max depth, then only update that node
+    if (it.getDepth() == pc_map_pair.octree->getTreeDepth()) {
+//      ROS_INFO_STREAM("it.getKey(): " << key_to_string(it.getKey()) << "  coords: (" << it.getX() << ", " << it.getY() << ", " << it.getZ() << ")");
+//      ROS_INFO_STREAM("Resolution: " << m_octree_resolution << "  pad: " << m_map_length/2);
+      int x = (m_map_length / 2 + it.getX()) / m_octree_resolution;
+      int y = (m_map_width / 2 + it.getY()) / m_octree_resolution;
+//      ROS_INFO_STREAM("Sum: (" << x << ", " << y << ")");
+      if (x < m_map_length / m_octree_resolution && y < m_map_width / m_octree_resolution) {
+        odds_sum[x][y] += it->getLogOdds();
+      } else {
+        ROS_ERROR_STREAM("Point outside!");
+      }
+    } else {
+      // This isn't a leaf at max depth. Time to iterate
+      int grid_num = 1 << (pc_map_pair.octree->getTreeDepth() - it.getDepth());
+      octomap::OcTreeKey minKey = it.getIndexKey();
+      int x = (m_map_length / 2 + it.getX()) / m_octree_resolution;
+      int y = (m_map_width / 2 + it.getY()) / m_octree_resolution;
+//      ROS_INFO("We did it?");
+      for (int dx = 0; dx < grid_num; dx++) {
+        for (int dy = 0; dy < grid_num; dy++) {
+          odds_sum[x + dx][y + dy] += it->getLogOdds();  // TODO: Which direction do I add??
+        }
+      }
+    }
+  }
+
+  // Transfer from log odds to normal probability
+  for (int i = 0; i < m_map_length / m_octree_resolution; i++) {
+    for (int j = 0; j < m_map_width / m_octree_resolution; j++) {
+      pc_map_pair.map->at<uchar>(i, j) = toCharProb(fromLogOdds(odds_sum[i][j]));
+    }
+  }
+}
+
+void Octomapper::create_map(pc_map_pair &pair) const {
+  int length = m_map_length / m_octree_resolution;
+  int width = m_map_width / m_octree_resolution;
+  pair.map = boost::make_shared<cv::Mat>(length, width, m_map_encoding, 127);
+}
+
+void Octomapper::insert_scan(const tf::Point &sensor_pos_tf, struct pc_map_pair &pc_map_pair,
+                             const Octomapper::PCL_point_cloud &raw_pc) const {
+//  ROS_INFO("Inserting scan");
+//  ROS_INFO_STREAM(
+//      "Sensor position: " << sensor_pos_tf.x() << ", " << sensor_pos_tf.y() << ", " << sensor_pos_tf.z() << ")");
+//  ROS_INFO_STREAM("Arbitrary cloud point" << raw_pc.at(0));
+
+  pcl::PointCloud<pcl::PointXYZ> within_range;
+//  filter_range(raw_pc, within_range);
+  pcl::PointCloud<pcl::PointXYZ> ground;
+  pcl::PointCloud<pcl::PointXYZ> nonground;
+  filter_ground_plane(raw_pc, ground, nonground);
+//  ROS_INFO("Filtered Ground");
+  octomap::point3d sensor_pos = octomap::pointTfToOctomap(sensor_pos_tf);
+
+  // Convert from PCL_point_cloud to octomap point cloud
+  octomap::Pointcloud octo_cloud;
+  PCL_to_Octomap(nonground, octo_cloud);
+//  ROS_INFO("Inserting pointcloud");
+//  ROS_INFO_STREAM("Num points: " << octo_cloud.size());
+  // TODO: Do we need to discretize to speed up? Probably not, since non occupied is so small
+  pc_map_pair.octree->insertPointCloud(octo_cloud, sensor_pos, m_max_range, false, false);
+
+  octomap::KeySet free_cells;
+  octomap::KeyRay key_ray;
+  octomap::OcTreeKey end_key;
+
+  for (auto it = ground.begin(); it != ground.end(); ++it) {
+    octomap::point3d point(it->x, it->y, it->z);
+
+    // If outside max range, set to max range in same direction
+    if ((m_max_range > 0.0) && ((point - sensor_pos).norm() > m_max_range)) {
+      point = sensor_pos + (point - sensor_pos).normalized() * m_max_range;
+    }
+
+    if (pc_map_pair.octree->computeRayKeys(sensor_pos, point, key_ray)) {
+      free_cells.insert(key_ray.begin(), key_ray.end());
+    }
+
+    if (pc_map_pair.octree->coordToKeyChecked(point, end_key)) {
+      //  updateMinKey?? updateMaxKey??
+    } else {
+      ROS_ERROR_STREAM("Could not generate Key for endpoint" << point);
+    }
+  }
+//  ROS_INFO("Done with finding all ground nodes");
+  for (const auto &free_cell : free_cells) {
+    pc_map_pair.octree->updateNode(free_cell, false);
+  }
+//  ROS_INFO("Done with inserting ground");
+  // TODO: When to generate occupancy grid?
+}
+
+void Octomapper::filter_ground_plane(const PCL_point_cloud &raw_pc, PCL_point_cloud &ground,
+                                     PCL_point_cloud &nonground) const {
+//  ROS_INFO_STREAM("Filtering Ground with " << raw_pc.size() << " points");
+  ground.header = raw_pc.header;
+  nonground.header = raw_pc.header;
+
+  if (raw_pc.size() < 50) {
+    // Hacky algorithm to detect ground
+    ROS_ERROR_STREAM("Pointcloud while filtering too small, skipping" << raw_pc.size());
+    nonground = raw_pc;
+  } else {
+    // Plane detection for ground removal
+    pcl::ModelCoefficientsPtr coefficients(new pcl::ModelCoefficients);
+    pcl::PointIndices::Ptr inliers(new pcl::PointIndices);
+
+    // create the segmentation object
+    pcl::SACSegmentation<pcl::PointXYZ> seg;
+    seg.setOptimizeCoefficients(true);
+
+    seg.setModelType(pcl::SACMODEL_PERPENDICULAR_PLANE);
+    seg.setMethodType(pcl::SAC_RANSAC);
+    seg.setMaxIterations(m_ransac_iterations);  // TODO: How many iterations
+    seg.setDistanceThreshold(m_ransac_distance_threshold);
+    seg.setAxis(Eigen::Vector3f(0, 0, 1));
+    seg.setEpsAngle(m_ransac_eps_angle);
+
+    PCL_point_cloud::Ptr cloud_filtered = raw_pc.makeShared();
+    // Create filtering object
+    pcl::ExtractIndices<pcl::PointXYZ> extract;
+    bool ground_plane_found = false;
+
+    seg.setInputCloud(cloud_filtered);
+    seg.segment(*inliers, *coefficients);
+    if (inliers->indices.empty()) {
+      ROS_INFO("PCL segmentation did not find a plane.");
+    } else {
+        ROS_DEBUG("Ground plane found: %zu/%zu inliers. Coeff: %f %f %f %f", inliers->indices.size(),
+                 cloud_filtered->size(), coefficients->values.at(0), coefficients->values.at(1),
+                 coefficients->values.at(2), coefficients->values.at(3));
+        extract.setInputCloud(cloud_filtered);
+        extract.setIndices(inliers);
+        extract.setNegative(false);
+        extract.filter(ground);
+
+        // remove ground points from full pointcloud
+        if (inliers->indices.size() != cloud_filtered->size()) {
+          extract.setNegative(true);
+          PCL_point_cloud out;
+          extract.filter(out);
+          nonground += out;
+          *cloud_filtered = out;
+        }
+        ground_plane_found = true;
+    }
+//    ROS_INFO_STREAM("Cloud_filtered Points: " << cloud_filtered->size());
+//    ROS_INFO_STREAM("ground points: " << ground.size());
+//    ROS_INFO_STREAM("nonground points: " << nonground.size());
+    if (!ground_plane_found) {
+      pcl::PassThrough<pcl::PointXYZ> second_pass;
+      second_pass.setFilterFieldName("z");
+      second_pass.setFilterLimits(-m_ground_filter_plane_dist, m_ground_filter_plane_dist);
+      second_pass.setInputCloud(cloud_filtered);
+      second_pass.filter(ground);
+
+      second_pass.setFilterLimitsNegative(true);
+      second_pass.filter(nonground);
+    }
+  }
+}
+

--- a/igvc_navigation/src/mapper/octomapper.cpp
+++ b/igvc_navigation/src/mapper/octomapper.cpp
@@ -88,34 +88,6 @@ void Octomapper::get_updated_map(struct pc_map_pair &pc_map_pair) const
   //}
 
   // Traverse entire tree
-  double minX, minY, minZ, maxX, maxY, maxZ;
-  pc_map_pair.octree->getMetricMin(minX, minY, minZ);
-  pc_map_pair.octree->getMetricMax(maxX, maxY, maxZ);
-
-  octomap::point3d minPt(minX, minY, minZ);
-  octomap::point3d maxPt(maxX, maxY, maxZ);
-  //  ROS_INFO_STREAM("Min: " << minPt << ", Max: " << maxPt);
-
-  minX = std::min(minX, -0.5 * m_map_length);
-  maxX = std::max(maxX, 0.5 * m_map_length);
-  minY = std::min(minY, -0.5 * m_map_width);
-  maxY = std::max(maxY, 0.5 * m_map_width);
-  minPt = octomap::point3d(minX, minY, minZ);
-  maxPt = octomap::point3d(maxX, maxY, maxZ);
-
-  octomap::OcTreeKey padded_min_key, padded_max_key;
-  int depth = pc_map_pair.octree->getTreeDepth();
-  if (!pc_map_pair.octree->coordToKeyChecked(minPt, depth, padded_min_key))
-  {
-    ROS_ERROR_STREAM("Could not create padded min OcTree key at " << minPt);
-  }
-  if (!pc_map_pair.octree->coordToKeyChecked(maxPt, depth, padded_max_key))
-  {
-    ROS_ERROR_STREAM("Could not create padded max OcTree key at " << maxPt);
-  }
-
-  //  ROS_INFO_STREAM("Min: " << minPt << ", Max: " << maxPt);
-  //  ROS_INFO_STREAM("MinKey: " << key_to_string(minKey) << ", Max: " << key_to_string(maxKey));
   std::vector<std::vector<float>> odds_sum(m_map_length / m_octree_resolution,
                                            std::vector<float>(m_map_width / m_octree_resolution,
                                                               m_odds_sum_default));  // TODO: Are these the right

--- a/igvc_navigation/src/mapper/octomapper.cpp
+++ b/igvc_navigation/src/mapper/octomapper.cpp
@@ -2,13 +2,17 @@
 
 #include <octomap/octomap.h>
 #include <octomap_ros/conversions.h>
+#include <omp.h>
+#include <unordered_set>
 
+using radians = double;
 // TODO: How to convert OcTree to occupancy grid?
 Octomapper::Octomapper(ros::NodeHandle pNh)
 {
   igvc::getParam(pNh, "octree/resolution", m_octree_resolution);
   igvc::getParam(pNh, "sensor_model/hit", m_prob_hit);
   igvc::getParam(pNh, "sensor_model/miss", m_prob_miss);
+  igvc::getParam(pNh, "sensor_model/miss_empty", m_prob_miss_empty);
   igvc::getParam(pNh, "sensor_model/min", m_thresh_min);
   igvc::getParam(pNh, "sensor_model/max", m_thresh_max);
   igvc::getParam(pNh, "sensor_model/max_range", m_max_range);
@@ -77,15 +81,6 @@ void Octomapper::get_updated_map(struct pc_map_pair &pc_map_pair) const
   {
     create_map(pc_map_pair);
   }
-  // TODO: Think about how to serialize / deserialize efficiently maybe?
-  // for (auto it = pc_map_pair.octree->changedKeysBegin(); it != pc_map_pair.octree->changedKeysEnd(); ++it)
-  //{
-  //  // TODO: Do we want the lowest depth here?
-  //  octomap::OcTreeNode* node = pc_map_pair.octree->search(it->first, 0);
-  //  auto coord = pc_map_pair.octree->keyToCoord(it->first);
-  //  int x = coord.x() * m_octree_resolution;
-  //  int y = coord.y() * m_octree_resolution;
-  //}
 
   // Traverse entire tree
   std::vector<std::vector<float>> odds_sum(m_map_length / m_octree_resolution,
@@ -137,10 +132,6 @@ void Octomapper::get_updated_map(struct pc_map_pair &pc_map_pair) const
     for (int j = 0; j < m_map_width / m_octree_resolution; j++)
     {
       pc_map_pair.map->at<uchar>(i, j) = toCharProb(fromLogOdds(odds_sum[i][j]));
-      if (pc_map_pair.map->at<uchar>(i, j) < m_floor_thresh)
-      {
-        pc_map_pair.map->at<uchar>(i, j) = 0;
-      }
     }
   }
 }
@@ -152,16 +143,9 @@ void Octomapper::create_map(pc_map_pair &pair) const
   pair.map = boost::make_shared<cv::Mat>(length, width, m_map_encoding, 127);
 }
 
-void Octomapper::insert_scan(const tf::Point &sensor_pos_tf, struct pc_map_pair &pc_map_pair,
-                             const Octomapper::PCL_point_cloud &raw_pc) const
+void Octomapper::insert_scan(const tf::Point& sensor_pos_tf, struct pc_map_pair& pc_map_pair,
+                 const PCL_point_cloud& raw_pc, const pcl::PointCloud<pcl::PointXYZ>& empty_pc) const
 {
-  //  ROS_INFO("Inserting scan");
-  //  ROS_INFO_STREAM(
-  //      "Sensor position: " << sensor_pos_tf.x() << ", " << sensor_pos_tf.y() << ", " << sensor_pos_tf.z() << ")");
-  //  ROS_INFO_STREAM("Arbitrary cloud point" << raw_pc.at(0));
-
-  pcl::PointCloud<pcl::PointXYZ> within_range;
-  //  filter_range(raw_pc, within_range);
   pcl::PointCloud<pcl::PointXYZ> ground;
   pcl::PointCloud<pcl::PointXYZ> nonground;
   if (m_use_ground_filter)
@@ -172,17 +156,19 @@ void Octomapper::insert_scan(const tf::Point &sensor_pos_tf, struct pc_map_pair 
   {
     nonground = std::move(raw_pc);
   }
+
   //  ROS_INFO("Filtered Ground");
   octomap::point3d sensor_pos = octomap::pointTfToOctomap(sensor_pos_tf);
 
   // Convert from PCL_point_cloud to octomap point cloud
   octomap::Pointcloud octo_cloud;
   PCL_to_Octomap(nonground, octo_cloud);
-  //  ROS_INFO("Inserting pointcloud");
-  //  ROS_INFO_STREAM("Num points: " << octo_cloud.size());
-  // TODO: Do we need to discretize to speed up? Probably not, since non occupied is so small
-  //  ROS_INFO_STREAM("Sensor pos: (" << sensor_pos.x() << ", " << sensor_pos.y() << ")");
+  octomap::Pointcloud octo_cloud_free;
+  PCL_to_Octomap(empty_pc, octo_cloud_free);
+
+  // Insert occupied into octree
   pc_map_pair.octree->insertPointCloud(octo_cloud, sensor_pos, m_max_range, false, false);
+  insert_free(octo_cloud_free, sensor_pos, pc_map_pair, false);
 
   if (m_use_ground_filter)
   {
@@ -222,6 +208,34 @@ void Octomapper::insert_scan(const tf::Point &sensor_pos_tf, struct pc_map_pair 
   }
   //  ROS_INFO("Done with inserting ground");
   // TODO: When to generate occupancy grid?
+}
+
+void Octomapper::insert_free(const octomap::Pointcloud &scan, octomap::point3d origin, pc_map_pair &pair,
+                             bool lazy_eval) const
+{
+  octomap::KeySet free_cells{};
+  pair.octree->setProbMiss(m_prob_miss_empty);
+
+//  omp_set_num_threads(m_openmp_threads);
+//#pragma omp parallel for schedule(guided)
+  for (int i = 0; i < (int)scan.size(); ++i)
+  {
+    octomap::KeyRay keyray;
+    const octomap::point3d &p = scan[i];
+    if (pair.octree->computeRayKeys(origin, p, keyray))
+    {
+//#pragma omp critical(free_insert)
+      {
+        free_cells.insert(keyray.begin(), keyray.end());
+      }
+    }
+  }
+
+  for (auto it = free_cells.begin(); it != free_cells.end(); ++it)
+  {
+    pair.octree->updateNode(*it, false, lazy_eval);
+  }
+  pair.octree->setProbMiss(m_prob_miss);
 }
 
 void Octomapper::filter_ground_plane(const PCL_point_cloud &raw_pc, PCL_point_cloud &ground,

--- a/igvc_navigation/src/mapper/octomapper.cpp
+++ b/igvc_navigation/src/mapper/octomapper.cpp
@@ -4,7 +4,8 @@
 #include <octomap_ros/conversions.h>
 
 // TODO: How to convert OcTree to occupancy grid?
-Octomapper::Octomapper(ros::NodeHandle pNh) {
+Octomapper::Octomapper(ros::NodeHandle pNh)
+{
   igvc::getParam(pNh, "octree/resolution", m_octree_resolution);
   igvc::getParam(pNh, "sensor_model/hit", m_prob_hit);
   igvc::getParam(pNh, "sensor_model/miss", m_prob_miss);
@@ -22,14 +23,18 @@ Octomapper::Octomapper(ros::NodeHandle pNh) {
   igvc::getParam(pNh, "map/log_odds_default", m_odds_sum_default);
   std::string map_encoding;
   igvc::getParam(pNh, "map/encoding", map_encoding);
-  if (map_encoding == "CV_8UC1") {
+  if (map_encoding == "CV_8UC1")
+  {
     m_map_encoding = CV_8UC1;
-  } else {
+  }
+  else
+  {
     m_map_encoding = CV_8UC1;
   }
 }
 
-void Octomapper::create_octree(pc_map_pair &pair) const {
+void Octomapper::create_octree(pc_map_pair &pair) const
+{
   pair.octree = boost::make_shared<octomap::OcTree>(m_octree_resolution);
   pair.octree->setProbHit(m_prob_hit);
   pair.octree->setProbMiss(m_prob_miss);
@@ -42,28 +47,34 @@ void Octomapper::create_octree(pc_map_pair &pair) const {
   pair.octree->setBBXMax(max);
 }
 
-void PCL_to_Octomap(const pcl::PointCloud<pcl::PointXYZ> &pcl, octomap::Pointcloud &octo) {
+void PCL_to_Octomap(const pcl::PointCloud<pcl::PointXYZ> &pcl, octomap::Pointcloud &octo)
+{
   sensor_msgs::PointCloud2 pc2;
   pcl::toROSMsg(pcl, pc2);
   octomap::pointCloud2ToOctomap(pc2, octo);
 }
 
-uchar toCharProb(float p) {
+uchar toCharProb(float p)
+{
   return static_cast<uchar>(p * 255);
 }
 
-float fromLogOdds(float log_odds) {
+float fromLogOdds(float log_odds)
+{
   return 1 - (1 / (1 + exp(log_odds)));
 }
 
-std::string key_to_string(octomap::OcTreeKey key) {
+std::string key_to_string(octomap::OcTreeKey key)
+{
   std::ostringstream out;
   out << std::hex << "(" << key.k[0] << ", " << key.k[1] << ", " << key[2] << ")";
   return out.str();
 }
 
-void Octomapper::get_updated_map(struct pc_map_pair &pc_map_pair) const {
-  if (pc_map_pair.map == nullptr) {
+void Octomapper::get_updated_map(struct pc_map_pair &pc_map_pair) const
+{
+  if (pc_map_pair.map == nullptr)
+  {
     create_map(pc_map_pair);
   }
   // TODO: Think about how to serialize / deserialize efficiently maybe?
@@ -83,7 +94,7 @@ void Octomapper::get_updated_map(struct pc_map_pair &pc_map_pair) const {
 
   octomap::point3d minPt(minX, minY, minZ);
   octomap::point3d maxPt(maxX, maxY, maxZ);
-//  ROS_INFO_STREAM("Min: " << minPt << ", Max: " << maxPt);
+  //  ROS_INFO_STREAM("Min: " << minPt << ", Max: " << maxPt);
 
   minX = std::min(minX, -0.5 * m_map_length);
   maxX = std::max(maxX, 0.5 * m_map_length);
@@ -94,39 +105,53 @@ void Octomapper::get_updated_map(struct pc_map_pair &pc_map_pair) const {
 
   octomap::OcTreeKey padded_min_key, padded_max_key;
   int depth = pc_map_pair.octree->getTreeDepth();
-  if (!pc_map_pair.octree->coordToKeyChecked(minPt, depth, padded_min_key)) {
+  if (!pc_map_pair.octree->coordToKeyChecked(minPt, depth, padded_min_key))
+  {
     ROS_ERROR_STREAM("Could not create padded min OcTree key at " << minPt);
   }
-  if (!pc_map_pair.octree->coordToKeyChecked(maxPt, depth, padded_max_key)) {
+  if (!pc_map_pair.octree->coordToKeyChecked(maxPt, depth, padded_max_key))
+  {
     ROS_ERROR_STREAM("Could not create padded max OcTree key at " << maxPt);
   }
 
-//  ROS_INFO_STREAM("Min: " << minPt << ", Max: " << maxPt);
-//  ROS_INFO_STREAM("MinKey: " << key_to_string(minKey) << ", Max: " << key_to_string(maxKey));
+  //  ROS_INFO_STREAM("Min: " << minPt << ", Max: " << maxPt);
+  //  ROS_INFO_STREAM("MinKey: " << key_to_string(minKey) << ", Max: " << key_to_string(maxKey));
   std::vector<std::vector<float>> odds_sum(m_map_length / m_octree_resolution,
                                            std::vector<float>(m_map_width / m_octree_resolution,
                                                               m_odds_sum_default));  // TODO: Are these the right
-  for (octomap::OcTree::iterator it = pc_map_pair.octree->begin(), end = pc_map_pair.octree->end(); it != end; ++it) {
+  for (octomap::OcTree::iterator it = pc_map_pair.octree->begin(), end = pc_map_pair.octree->end(); it != end; ++it)
+  {
     // If this is a leaf at max depth, then only update that node
-    if (it.getDepth() == pc_map_pair.octree->getTreeDepth()) {
+    if (it.getDepth() == pc_map_pair.octree->getTreeDepth())
+    {
       int x = (m_map_length / 2 + it.getX()) / m_octree_resolution;
       int y = (m_map_width / 2 + it.getY()) / m_octree_resolution;
-      if (x < m_map_length / m_octree_resolution && y < m_map_width / m_octree_resolution) {
+      if (x < m_map_length / m_octree_resolution && y < m_map_width / m_octree_resolution)
+      {
         odds_sum[x][y] += it->getLogOdds();
-      } else {
+      }
+      else
+      {
         ROS_ERROR_STREAM("Point outside!");
       }
-    } else {
+    }
+    else
+    {
       // This isn't a leaf at max depth. Time to iterate
       int grid_num = 1 << (pc_map_pair.octree->getTreeDepth() - it.getDepth());
       int x = (m_map_length / 2 + it.getX()) / m_octree_resolution;
       int y = (m_map_width / 2 + it.getY()) / m_octree_resolution;
-//      ROS_INFO("We did it?");
-      for (int dx = 0; dx < grid_num; dx++) {
-        for (int dy = 0; dy < grid_num; dy++) {
-          if (x < m_map_length / m_octree_resolution && y < m_map_width / m_octree_resolution) {
+      //      ROS_INFO("We did it?");
+      for (int dx = 0; dx < grid_num; dx++)
+      {
+        for (int dy = 0; dy < grid_num; dy++)
+        {
+          if (x < m_map_length / m_octree_resolution && y < m_map_width / m_octree_resolution)
+          {
             odds_sum[x + dx][y + dy] += it->getLogOdds();
-          } else {
+          }
+          else
+          {
             ROS_ERROR_STREAM("Point outside!");
           }
         }
@@ -135,8 +160,10 @@ void Octomapper::get_updated_map(struct pc_map_pair &pc_map_pair) const {
   }
 
   // Transfer from log odds to normal probability
-  for (int i = 0; i < m_map_length / m_octree_resolution; i++) {
-    for (int j = 0; j < m_map_width / m_octree_resolution; j++) {
+  for (int i = 0; i < m_map_length / m_octree_resolution; i++)
+  {
+    for (int j = 0; j < m_map_width / m_octree_resolution; j++)
+    {
       pc_map_pair.map->at<uchar>(i, j) = toCharProb(fromLogOdds(odds_sum[i][j]));
       if (pc_map_pair.map->at<uchar>(i, j) < m_floor_thresh)
       {
@@ -146,84 +173,100 @@ void Octomapper::get_updated_map(struct pc_map_pair &pc_map_pair) const {
   }
 }
 
-void Octomapper::create_map(pc_map_pair &pair) const {
+void Octomapper::create_map(pc_map_pair &pair) const
+{
   int length = m_map_length / m_octree_resolution;
   int width = m_map_width / m_octree_resolution;
   pair.map = boost::make_shared<cv::Mat>(length, width, m_map_encoding, 127);
 }
 
 void Octomapper::insert_scan(const tf::Point &sensor_pos_tf, struct pc_map_pair &pc_map_pair,
-                             const Octomapper::PCL_point_cloud &raw_pc) const {
-//  ROS_INFO("Inserting scan");
-//  ROS_INFO_STREAM(
-//      "Sensor position: " << sensor_pos_tf.x() << ", " << sensor_pos_tf.y() << ", " << sensor_pos_tf.z() << ")");
-//  ROS_INFO_STREAM("Arbitrary cloud point" << raw_pc.at(0));
+                             const Octomapper::PCL_point_cloud &raw_pc) const
+{
+  //  ROS_INFO("Inserting scan");
+  //  ROS_INFO_STREAM(
+  //      "Sensor position: " << sensor_pos_tf.x() << ", " << sensor_pos_tf.y() << ", " << sensor_pos_tf.z() << ")");
+  //  ROS_INFO_STREAM("Arbitrary cloud point" << raw_pc.at(0));
 
   pcl::PointCloud<pcl::PointXYZ> within_range;
-//  filter_range(raw_pc, within_range);
+  //  filter_range(raw_pc, within_range);
   pcl::PointCloud<pcl::PointXYZ> ground;
   pcl::PointCloud<pcl::PointXYZ> nonground;
   if (m_use_ground_filter)
   {
     filter_ground_plane(raw_pc, ground, nonground);
-  } else {
+  }
+  else
+  {
     nonground = std::move(raw_pc);
   }
-//  ROS_INFO("Filtered Ground");
+  //  ROS_INFO("Filtered Ground");
   octomap::point3d sensor_pos = octomap::pointTfToOctomap(sensor_pos_tf);
 
   // Convert from PCL_point_cloud to octomap point cloud
   octomap::Pointcloud octo_cloud;
   PCL_to_Octomap(nonground, octo_cloud);
-//  ROS_INFO("Inserting pointcloud");
-//  ROS_INFO_STREAM("Num points: " << octo_cloud.size());
+  //  ROS_INFO("Inserting pointcloud");
+  //  ROS_INFO_STREAM("Num points: " << octo_cloud.size());
   // TODO: Do we need to discretize to speed up? Probably not, since non occupied is so small
-//  ROS_INFO_STREAM("Sensor pos: (" << sensor_pos.x() << ", " << sensor_pos.y() << ")");
+  //  ROS_INFO_STREAM("Sensor pos: (" << sensor_pos.x() << ", " << sensor_pos.y() << ")");
   pc_map_pair.octree->insertPointCloud(octo_cloud, sensor_pos, m_max_range, false, false);
 
-  if (m_use_ground_filter) {
+  if (m_use_ground_filter)
+  {
     octomap::KeySet free_cells;
     octomap::KeyRay key_ray;
     octomap::OcTreeKey end_key;
 
-    for (auto it = ground.begin(); it != ground.end(); ++it) {
+    for (auto it = ground.begin(); it != ground.end(); ++it)
+    {
       octomap::point3d point(it->x, it->y, it->z);
 
       // If outside max range, set to max range in same direction
-      if ((m_max_range > 0.0) && ((point - sensor_pos).norm() > m_max_range)) {
+      if ((m_max_range > 0.0) && ((point - sensor_pos).norm() > m_max_range))
+      {
         point = sensor_pos + (point - sensor_pos).normalized() * m_max_range;
       }
 
-      if (pc_map_pair.octree->computeRayKeys(sensor_pos, point, key_ray)) {
+      if (pc_map_pair.octree->computeRayKeys(sensor_pos, point, key_ray))
+      {
         free_cells.insert(key_ray.begin(), key_ray.end());
       }
 
-      if (pc_map_pair.octree->coordToKeyChecked(point, end_key)) {
+      if (pc_map_pair.octree->coordToKeyChecked(point, end_key))
+      {
         //  updateMinKey?? updateMaxKey??
-      } else {
+      }
+      else
+      {
         ROS_ERROR_STREAM("Could not generate Key for endpoint" << point);
       }
     }
-//  ROS_INFO("Done with finding all ground nodes");
-    for (const auto &free_cell : free_cells) {
+    //  ROS_INFO("Done with finding all ground nodes");
+    for (const auto &free_cell : free_cells)
+    {
       pc_map_pair.octree->updateNode(free_cell, false);
     }
   }
-//  ROS_INFO("Done with inserting ground");
+  //  ROS_INFO("Done with inserting ground");
   // TODO: When to generate occupancy grid?
 }
 
 void Octomapper::filter_ground_plane(const PCL_point_cloud &raw_pc, PCL_point_cloud &ground,
-                                     PCL_point_cloud &nonground) const {
-//  ROS_INFO_STREAM("Filtering Ground with " << raw_pc.size() << " points");
+                                     PCL_point_cloud &nonground) const
+{
+  //  ROS_INFO_STREAM("Filtering Ground with " << raw_pc.size() << " points");
   ground.header = raw_pc.header;
   nonground.header = raw_pc.header;
 
-  if (raw_pc.size() < 50) {
+  if (raw_pc.size() < 50)
+  {
     // Hacky algorithm to detect ground
     ROS_ERROR_STREAM("Pointcloud while filtering too small, skipping" << raw_pc.size());
     nonground = raw_pc;
-  } else {
+  }
+  else
+  {
     // Plane detection for ground removal
     pcl::ModelCoefficientsPtr coefficients(new pcl::ModelCoefficients);
     pcl::PointIndices::Ptr inliers(new pcl::PointIndices);
@@ -246,9 +289,12 @@ void Octomapper::filter_ground_plane(const PCL_point_cloud &raw_pc, PCL_point_cl
 
     seg.setInputCloud(cloud_filtered);
     seg.segment(*inliers, *coefficients);
-    if (inliers->indices.empty()) {
+    if (inliers->indices.empty())
+    {
       ROS_INFO("PCL segmentation did not find a plane.");
-    } else {
+    }
+    else
+    {
       ROS_DEBUG("Ground plane found: %zu/%zu inliers. Coeff: %f %f %f %f", inliers->indices.size(),
                 cloud_filtered->size(), coefficients->values.at(0), coefficients->values.at(1),
                 coefficients->values.at(2), coefficients->values.at(3));
@@ -258,7 +304,8 @@ void Octomapper::filter_ground_plane(const PCL_point_cloud &raw_pc, PCL_point_cl
       extract.filter(ground);
 
       // remove ground points from full pointcloud
-      if (inliers->indices.size() != cloud_filtered->size()) {
+      if (inliers->indices.size() != cloud_filtered->size())
+      {
         extract.setNegative(true);
         PCL_point_cloud out;
         extract.filter(out);
@@ -267,10 +314,11 @@ void Octomapper::filter_ground_plane(const PCL_point_cloud &raw_pc, PCL_point_cl
       }
       ground_plane_found = true;
     }
-//    ROS_INFO_STREAM("Cloud_filtered Points: " << cloud_filtered->size());
-//    ROS_INFO_STREAM("ground points: " << ground.size());
-//    ROS_INFO_STREAM("nonground points: " << nonground.size());
-    if (!ground_plane_found) {
+    //    ROS_INFO_STREAM("Cloud_filtered Points: " << cloud_filtered->size());
+    //    ROS_INFO_STREAM("ground points: " << ground.size());
+    //    ROS_INFO_STREAM("nonground points: " << nonground.size());
+    if (!ground_plane_found)
+    {
       pcl::PassThrough<pcl::PointXYZ> second_pass;
       second_pass.setFilterFieldName("z");
       second_pass.setFilterLimits(-m_ground_filter_plane_dist, m_ground_filter_plane_dist);
@@ -282,4 +330,3 @@ void Octomapper::filter_ground_plane(const PCL_point_cloud &raw_pc, PCL_point_cl
     }
   }
 }
-

--- a/igvc_navigation/src/mapper/octomapper.h
+++ b/igvc_navigation/src/mapper/octomapper.h
@@ -1,0 +1,68 @@
+#ifndef PROJECT_OCTOMAPPER_H
+#define PROJECT_OCTOMAPPER_H
+
+#include <ros/ros.h>
+
+#include <octomap/octomap.h>
+#include <octomap_ros/conversions.h>
+
+#include <pcl/filters/extract_indices.h>
+#include <pcl/filters/passthrough.h>
+#include <pcl/sample_consensus/method_types.h>
+#include <pcl/sample_consensus/model_types.h>
+#include <pcl/segmentation/sac_segmentation.h>
+#include <pcl_ros/point_cloud.h>
+
+#include <tf/message_filter.h>
+#include <tf/transform_listener.h>
+#include <boost/shared_ptr.hpp>
+
+#include <igvc_msgs/map.h>
+#include <igvc_utils/NodeUtils.hpp>
+
+#include <cv_bridge/cv_bridge.h>
+#include <opencv2/core/eigen.hpp>
+#include <opencv2/opencv.hpp>
+
+struct pc_map_pair
+{
+  boost::shared_ptr<octomap::OcTree> octree;
+  boost::shared_ptr<cv::Mat> map;
+};
+
+class Octomapper
+{
+public:
+  using PCL_point_cloud = pcl::PointCloud<pcl::PointXYZ>;
+
+  explicit Octomapper(ros::NodeHandle pNh);
+  void create_octree(pc_map_pair& pair) const;
+  void insert_scan(const tf::Point& sensor_pos_tf, struct pc_map_pair& pc_map_pair,
+                   const PCL_point_cloud& raw_pc) const;
+  void get_updated_map(struct pc_map_pair& pc_map_pair) const;
+  void filter_ground_plane(const PCL_point_cloud& pc, PCL_point_cloud& ground, PCL_point_cloud& nonground) const;
+
+private:
+  void filter_range(const pcl::PointCloud<pcl::PointXYZ>& raw_pc, pcl::PointCloud<pcl::PointXYZ>& within_range) const;
+  void create_map(pc_map_pair& pair) const;
+
+  ros::NodeHandle pNh;
+  double m_octree_resolution;
+  double m_prob_hit;
+  double m_prob_miss;
+  double m_thresh_min;
+  double m_thresh_max;
+  double m_max_range;
+  int m_ransac_iterations;
+  double m_ransac_distance_threshold;
+  double m_ransac_eps_angle;
+  float m_ground_filter_plane_dist;
+  int m_map_length;
+  int m_map_width;
+  int m_map_encoding;
+  float m_odds_sum_default;
+
+  // std::unique_ptr<tf::MessageFilter<PCL_point_cloud>> msg_filter;
+};
+
+#endif  // PROJECT_OCTOMAPPER_H

--- a/igvc_navigation/src/mapper/octomapper.h
+++ b/igvc_navigation/src/mapper/octomapper.h
@@ -47,6 +47,7 @@ private:
   void create_map(pc_map_pair& pair) const;
 
   ros::NodeHandle pNh;
+  bool m_use_ground_filter;
   double m_octree_resolution;
   double m_prob_hit;
   double m_prob_miss;

--- a/igvc_navigation/src/mapper/octomapper.h
+++ b/igvc_navigation/src/mapper/octomapper.h
@@ -32,30 +32,38 @@ struct pc_map_pair
 
 class Octomapper
 {
+  using radians = double;
+
 public:
   using PCL_point_cloud = pcl::PointCloud<pcl::PointXYZ>;
 
   explicit Octomapper(ros::NodeHandle pNh);
   void create_octree(pc_map_pair& pair) const;
   void insert_scan(const tf::Point& sensor_pos_tf, struct pc_map_pair& pc_map_pair,
-                   const PCL_point_cloud& raw_pc) const;
+                   const PCL_point_cloud& raw_pc, const pcl::PointCloud<pcl::PointXYZ>& empty_pc) const;
   void get_updated_map(struct pc_map_pair& pc_map_pair) const;
   void filter_ground_plane(const PCL_point_cloud& pc, PCL_point_cloud& ground, PCL_point_cloud& nonground) const;
 
 private:
   void filter_range(const pcl::PointCloud<pcl::PointXYZ>& raw_pc, pcl::PointCloud<pcl::PointXYZ>& within_range) const;
   void create_map(pc_map_pair& pair) const;
+  void insert_free(const octomap::Pointcloud& scan, octomap::point3d origin, pc_map_pair& pair,
+                               bool lazy_eval) const;
+  inline int discretize(radians angle) const;
 
   ros::NodeHandle pNh;
   bool m_use_ground_filter;
   double m_octree_resolution;
   double m_prob_hit;
   double m_prob_miss;
+  double m_prob_miss_empty;
   double m_thresh_min;
   double m_thresh_max;
   double m_max_range;
   double m_floor_thresh;
+
   int m_ransac_iterations;
+  int m_openmp_threads;
   double m_ransac_distance_threshold;
   double m_ransac_eps_angle;
   float m_ground_filter_plane_dist;

--- a/igvc_navigation/src/mapper/octomapper.h
+++ b/igvc_navigation/src/mapper/octomapper.h
@@ -54,6 +54,7 @@ private:
   double m_thresh_min;
   double m_thresh_max;
   double m_max_range;
+  double m_floor_thresh;
   int m_ransac_iterations;
   double m_ransac_distance_threshold;
   double m_ransac_eps_angle;

--- a/igvc_navigation/src/path_follower/SmoothControl.cpp
+++ b/igvc_navigation/src/path_follower/SmoothControl.cpp
@@ -27,8 +27,8 @@ void SmoothControl::getTrajectory(igvc_msgs::velocity_pair& vel, nav_msgs::PathC
     if (i == 0)
     {
       geometry_msgs::PoseStamped start;
-      start.pose.position.x = this->cur_pos.x;
-      start.pose.position.y = this->cur_pos.y;
+      start.pose.position.x = this->cur_pos.x();
+      start.pose.position.y = this->cur_pos.y();
       trajectory.poses.push_back(start);
 
       vel.left_velocity = action[0] - action[1] * axle_length / 2;
@@ -45,8 +45,8 @@ void SmoothControl::getTrajectory(igvc_msgs::velocity_pair& vel, nav_msgs::PathC
     }
 
     geometry_msgs::PoseStamped pose;
-    pose.pose.position.x = this->cur_pos.x;
-    pose.pose.position.y = this->cur_pos.y;
+    pose.pose.position.x = this->cur_pos.x();
+    pose.pose.position.y = this->cur_pos.y();
     trajectory.poses.push_back(pose);
   }
 }
@@ -155,8 +155,8 @@ void SmoothControl::getEgocentricAngles(nav_msgs::PathConstPtr path, unsigned in
 
 void SmoothControl::getLineOfSightAndHeading()
 {
-  double slope_x = target.x - cur_pos.x;
-  double slope_y = target.y - cur_pos.y;
+  double slope_x = target.x() - cur_pos.x();
+  double slope_y = target.y() - cur_pos.y();
 
   // line of sight
   Eigen::Vector3d los(slope_x, slope_y, 0);
@@ -164,7 +164,7 @@ void SmoothControl::getLineOfSightAndHeading()
   this->los_ << los;
 
   // get current robot heading in vector format
-  Eigen::Vector3d heading(std::cos(this->cur_pos.yaw), std::sin(this->cur_pos.yaw), 0);
+  Eigen::Vector3d heading(std::cos(this->cur_pos.yaw()), std::sin(this->cur_pos.yaw()), 0);
   this->heading_ << heading;
 }
 
@@ -226,7 +226,7 @@ unsigned int SmoothControl::getClosestPosition(nav_msgs::PathConstPtr path)
 
   double temp = \
       cur_pos.distTo(path->poses[path_index].pose.position.x,
-                                       path->poses[path_index].pose.position.y);
+                     path->poses[path_index].pose.position.y);
 
   while (path_index < path->poses.size() && temp <= closest)
   {
@@ -237,7 +237,7 @@ unsigned int SmoothControl::getClosestPosition(nav_msgs::PathConstPtr path)
     path_index++;
     temp = \
         cur_pos.distTo(path->poses[path_index].pose.position.x,
-                                         path->poses[path_index].pose.position.y);
+                       path->poses[path_index].pose.position.y);
   }
 
   return path_index;

--- a/igvc_navigation/src/path_follower/main.cpp
+++ b/igvc_navigation/src/path_follower/main.cpp
@@ -66,7 +66,10 @@ void position_callback(const nav_msgs::OdometryConstPtr& msg)
   RobotState cur_pos(msg);
 
   double goal_dist = cur_pos.distTo(waypoint->point.x, waypoint->point.y);
-  ROS_INFO_STREAM("Distance to waypoint: " << goal_dist << "(m.)");
+  if (debug)
+  {
+    ROS_INFO_STREAM("Distance to waypoint: " << goal_dist << "(m.)");
+  }
 
   ros::Time time = msg->header.stamp;
   igvc_msgs::velocity_pair vel;  // immediate velocity command
@@ -104,8 +107,8 @@ void position_callback(const nav_msgs::OdometryConstPtr& msg)
     geometry_msgs::PointStamped target_point;
     target_point.header.frame_id = "/odom";
     target_point.header.stamp = time;
-    target_point.point.x = target.x;
-    target_point.point.y = target.y;
+    target_point.point.x = target.x();
+    target_point.point.y = target.y();
     target_pub.publish(target_point);
 
     if (debug)

--- a/igvc_utils/include/igvc_utils/RobotState.hpp
+++ b/igvc_utils/include/igvc_utils/RobotState.hpp
@@ -1,5 +1,6 @@
 #ifndef ROBOTSTATE_H
 #define ROBOTSTATE_H
+#pragma once
 
 #include <nav_msgs/Odometry.h>
 #include <tf/transform_datatypes.h>
@@ -9,11 +10,14 @@
 class RobotState
 {
 public:
-  double x{ 0 };
-  double y{ 0 };
-  double roll{ 0 };
-  double pitch{ 0 };
-  double yaw{ 0 };
+  // double x{ 0 };
+  // double y{ 0 };
+  // double z{ 0 };
+  // double roll{ 0 };
+  // double pitch{ 0 };
+  // double yaw{ 0 };
+  tf::Transform transform;
+  ros::Time stamp{ 0 };
 
   friend std::ostream &operator<<(std::ostream &out, const RobotState &state);
 
@@ -24,65 +28,188 @@ public:
     setState(msg);
   }
 
+  explicit RobotState(double x, double y, double yaw)
+  {
+    transform.setOrigin(tf::Vector3(x, y, 0));
+    tf::Matrix3x3 rot;
+    rot.setRPY(0, 0, yaw);
+    transform.setBasis(rot);
+  }
+
+  explicit RobotState(const tf::StampedTransform &stamped_transform, ros::Time stamp)
+      : transform(stamped_transform), stamp(stamp)
+  {
+  }
+
+  explicit RobotState(const tf::Transform& transform) : transform(transform) { }
+
+  double x() const;
+  double y() const;
+  double z() const;
+  double roll() const;
+  double pitch() const;
+  double yaw() const;
+  double quat_x() const;
+  double quat_y() const;
+  double quat_z() const;
+  double quat_w() const;
+
+  void set_x(double x);
+  void set_y(double y);
+  void set_z(double z);
+  void set_roll(double roll);
+  void set_pitch(double pitch);
+  void set_yaw(double yaw);
+
   // set state using an odometry msg
   void setState(const nav_msgs::Odometry::ConstPtr &msg)
   {
-    x = msg->pose.pose.position.x;
-    y = msg->pose.pose.position.y;
+    double x = msg->pose.pose.position.x;
+    double y = msg->pose.pose.position.y;
+    double z = msg->pose.pose.position.z;
+    //    tf::Matrix3x3(quaternion).getRPY(roll, pitch, yaw);
     tf::Quaternion quaternion;
     tf::quaternionMsgToTF(msg->pose.pose.orientation, quaternion);
-    tf::Matrix3x3(quaternion).getRPY(roll, pitch, yaw);
+    transform.setRotation(quaternion);
+    transform.setOrigin(tf::Vector3(x, y, z));
   }
 
   // set state via a transform
   void setState(const tf::StampedTransform &transform)
   {
-    x = transform.getOrigin().x();
-    y = transform.getOrigin().y();
-    tf::Matrix3x3(transform.getRotation()).getRPY(roll, pitch, yaw);
+    this->transform = transform;
   }
 
   // set state via a 3D Eigen vector
   void setState(const Eigen::Vector3d pose)
   {
-    x = pose[0];
-    y = pose[1];
-    yaw = pose[2];
+    transform.setOrigin(tf::Vector3(pose[0], pose[1], 0));
+    tf::Matrix3x3 rot = transform.getBasis();
+    double r, p, y;
+    rot.getRPY(r, p, y);
+    rot.setEulerYPR(r, p, pose[2]);
+    transform.setBasis(rot);
   }
 
-  Eigen::Vector3d getVector3d()
+  Eigen::Vector3d getVector3d() const
   {
-    return { x, y, yaw };
+    return { x(), y(), yaw() };
   }
 
   bool operator==(const RobotState &other)
   {
-    return std::tie(x, y, roll, pitch, yaw) == std::tie(other.x, other.y, other.roll, other.pitch, other.yaw);
+    return transform == other.transform;
+  }
+
+  void operator*=(const tf::Transform other)
+  {
+    transform *= other;
+  }
+
+  RobotState operator*(const RobotState& other) const
+  {
+    RobotState combined(transform * other.transform);
+    return combined;
+  }
+
+  /**
+   * Adds the state vector to the current transform. Use case is adding noise.
+   * @param state
+   * @return
+   */
+  void operator+=(Eigen::Matrix<double, 6, 1> state)
+  {
+    transform.setOrigin(tf::Vector3(x() + state(0), y() + state(1), z() + state(2)));
+    double r, p, y;
+    transform.getBasis().getRPY(r, p, y);
+    transform.getBasis().setRPY(r + state(3), p + state(4), y + state(5));
   }
 
   /**
   returns the euclidian distance from the current robot position to a
   specified position [x2,y2]
   */
-  double distTo(double x2, double y2)
+  double distTo(double x2, double y2) const
   {
-    return igvc::get_distance(this->x, this->y, x2, y2);
+    return igvc::get_distance(this->x(), this->y(), x2, y2);
   }
 
   /**
   returns the euclidian distance from the current robot position to another
   RobotState
   */
-  double distTo(RobotState other)
+  double distTo(RobotState other) const
   {
-    return igvc::get_distance(this->x, this->y, other.x, other.y);
+    return igvc::get_distance(this->x(), this->y(), other.x(), other.y());
   }
 };
 
+inline double RobotState::x() const
+{
+  return transform.getOrigin().x();
+}
+
+inline double RobotState::y() const
+{
+  return transform.getOrigin().y();
+}
+
+inline double RobotState::z() const
+{
+  return transform.getOrigin().z();
+}
+
+inline double RobotState::roll() const
+{
+  double r, p, y;
+  transform.getBasis().getRPY(r, p, y);
+  return r;
+}
+
+inline double RobotState::pitch() const
+{
+  double r, p, y;
+  transform.getBasis().getRPY(r, p, y);
+  return p;
+}
+
+inline double RobotState::yaw() const
+{
+  double r, p, y;
+  transform.getBasis().getRPY(r, p, y);
+  return y;
+}
+
+inline double RobotState::quat_x() const { return transform.getRotation().x(); }
+inline double RobotState::quat_y() const { return transform.getRotation().y(); }
+inline double RobotState::quat_z() const { return transform.getRotation().z(); }
+inline double RobotState::quat_w() const { return transform.getRotation().w(); }
+
+
 inline std::ostream &operator<<(std::ostream &out, const RobotState &state)
 {
-  out << "(" << state.x << ", " << state.y << ", " << state.yaw << ")";
+  out << "(" << state.x() << ", " << state.y() << ", " << state.yaw() << ")";
   return out;
+}
+
+inline void RobotState::set_x(double x) { transform.setOrigin(tf::Vector3(x, y(), z())); }
+inline void RobotState::set_y(double y) { transform.setOrigin(tf::Vector3(x(), y, z())); }
+inline void RobotState::set_z(double z) { transform.setOrigin(tf::Vector3(x(), y(), z)); }
+inline void RobotState::set_roll(double roll) {
+  tf::Matrix3x3 t = transform.getBasis();
+  t.setRPY(roll, pitch(), yaw());
+  transform.setBasis(t);
+}
+inline void RobotState::set_pitch(double pitch) {
+  tf::Matrix3x3 t = transform.getBasis();
+  t.setRPY(roll(), pitch, yaw());
+  transform.setBasis(t);
+}
+
+inline void RobotState::set_yaw(double yaw) {
+  tf::Matrix3x3 t = transform.getBasis();
+  t.setRPY(roll(), pitch(), yaw);
+  transform.setBasis(t);
 }
 
 #endif  // ROBOTSTATE_H


### PR DESCRIPTION
This PR replaces the old mapper with a new mapper which uses an OcTree backed occupancy grid mapper to map the surroundings based on data from the lidar, by mapping with known poses. The parameters are stored in octomap.yaml.

Currently, this mapper does not handle semantic segmentation data from the camera for line detection.

Todo:

- [ ] Handle semantic segmentation information about lines and potholes
- [ ] Incorporate the sensor model during update (ie. when objects are outside the detection range
