### PR TITLE
Changed encoder timestamp to beginning of dt instead of end of dt

### DIFF
--- a/igvc_platform/src/motor_controller/main.cpp
+++ b/igvc_platform/src/motor_controller/main.cpp
@@ -272,7 +272,7 @@ int main(int argc, char** argv)
       enc_msg.left_velocity = response.speed_l;
       enc_msg.right_velocity = response.speed_r;
       enc_msg.duration = response.dt_sec;
-      enc_msg.header.stamp = ros::Time::now();
+      enc_msg.header.stamp = ros::Time::now() - ros::Duration(response.dt_sec);
       enc_pub.publish(enc_msg);
 
       ROS_INFO_STREAM("Rate: " << response.dt_sec << "s.");


### PR DESCRIPTION
This PR changes the timestamp for encoders from `ros::Time::now()` to `ros::Time::now() - ros::Duration(response.dt_sec)`, fixing #361.