### PR TITLE
Path follower pathing to "mini-waypoints" within the path for Lyapunov stability

### DIFF
--- a/igvc_navigation/CMakeLists.txt
+++ b/igvc_navigation/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system)
 find_package(PCL REQUIRED filters)
 
-set(CMAKE_CXX_FLAGS "-g -std=c++11 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-g -std=c++17 -Wall ${CMAKE_CXX_FLAGS}")
 
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed

--- a/igvc_navigation/launch/follower.launch
+++ b/igvc_navigation/launch/follower.launch
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<launch>
+    <!-- Follower -->
+    <node name="path_follower" pkg="igvc_navigation" type="path_follower" output="screen" >
+        <!-- Maxmimum wheel velocity allowed before stopping motors -->
+        <param name="maximum_vel" type="double" value="2"/>
+        <param name="axle_length" type="double" value="0.52"/>
+        <!-- Distance along the path to generate smooth control law for  -->
+        <param name="lookahead_dist" type="double" value="1.3"/>
+        <!-- Frequency (hz) at which simulation is done -->
+        <param name="simulation_frequency" type="double" value="10.0"/>
+        <!-- How many seconds in the future should be simulated-->
+        <param name="simulation_horizon" type="double" value="5.0"/>
+        <!-- How far away robot should be from the waypoint before it stops -->
+        <param name="stop_dist" type="double" value="0.7"/>
+        <!-- Smooth Control Parameters -->
+        <param name="target_v" type="double" value="0.4"/>
+        <param name="k1" type="double" value="1.8"/>
+        <param name="k2" type="double" value="5"/>
+        <param name="debug" type="bool" value="true"/>
+    </node>
+</launch>

--- a/igvc_navigation/launch/follower.launch
+++ b/igvc_navigation/launch/follower.launch
@@ -18,7 +18,7 @@
         <!-- Smooth Control Parameters -->
         <param name="target_v" type="double" value="0.4"/>
         <param name="k1" type="double" value="1.8"/>
-        <param name="k2" type="double" value="2"/>
+        <param name="k2" type="double" value="5"/>
         <param name="debug" type="bool" value="true"/>
     </node>
 </launch>

--- a/igvc_navigation/launch/follower.launch
+++ b/igvc_navigation/launch/follower.launch
@@ -6,17 +6,19 @@
         <param name="maximum_vel" type="double" value="2"/>
         <param name="axle_length" type="double" value="0.52"/>
         <!-- Distance along the path to generate smooth control law for  -->
-        <param name="lookahead_dist" type="double" value="1.3"/>
+        <param name="lookahead_dist" type="double" value="0.4"/>
         <!-- Frequency (hz) at which simulation is done -->
         <param name="simulation_frequency" type="double" value="10.0"/>
         <!-- How many seconds in the future should be simulated-->
         <param name="simulation_horizon" type="double" value="5.0"/>
+        <param name="target_reached_distance" type="double" value="0.1"/>
+        <param name="target_move_threshold" type="double" value="0.1"/>
         <!-- How far away robot should be from the waypoint before it stops -->
         <param name="stop_dist" type="double" value="0.7"/>
         <!-- Smooth Control Parameters -->
         <param name="target_v" type="double" value="0.4"/>
         <param name="k1" type="double" value="1.8"/>
-        <param name="k2" type="double" value="5"/>
+        <param name="k2" type="double" value="2"/>
         <param name="debug" type="bool" value="true"/>
     </node>
 </launch>

--- a/igvc_navigation/src/path_follower/CMakeLists.txt
+++ b/igvc_navigation/src/path_follower/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_executable(path_follower path_follower.cpp smooth_control.cpp path_follower.h)
 add_dependencies(path_follower igvc_msgs_gencpp)
 target_link_libraries(path_follower ${catkin_LIBRARIES})
+

--- a/igvc_navigation/src/path_follower/path_follower.cpp
+++ b/igvc_navigation/src/path_follower/path_follower.cpp
@@ -41,7 +41,7 @@ PathFollower::PathFollower()
   igvc::param(pNh, "simulation_frequency", simulation_frequency, 100.0);
   igvc::param(pNh, "lookahead_dist", lookahead_dist, 2.0);
   igvc::param(pNh, "simulation_horizon", simulation_horizon, 5.0);
-  igvc::param(pNh, "target_reached_distance", target_reached_distance, 0.5);
+  igvc::param(pNh, "target_reached_distance", target_reached_distance, 0.05);
   igvc::param(pNh, "target_move_threshold", target_move_threshold, 0.05);
   if (simulation_frequency <= 0)
   {

--- a/igvc_navigation/src/path_follower/path_follower.cpp
+++ b/igvc_navigation/src/path_follower/path_follower.cpp
@@ -31,6 +31,8 @@ PathFollower::PathFollower()
   double k2;
   double simulation_frequency;
   double lookahead_dist;
+  double target_reached_distance;
+  double target_move_threshold;
   seconds simulation_horizon;
   igvc::param(pNh, "target_v", target_velocity, 1.0);
   igvc::param(pNh, "axle_length", axle_length, 0.52);
@@ -39,14 +41,17 @@ PathFollower::PathFollower()
   igvc::param(pNh, "simulation_frequency", simulation_frequency, 100.0);
   igvc::param(pNh, "lookahead_dist", lookahead_dist, 2.0);
   igvc::param(pNh, "simulation_horizon", simulation_horizon, 5.0);
+  igvc::param(pNh, "target_reached_distance", target_reached_distance, 0.5);
+  igvc::param(pNh, "target_move_threshold", target_move_threshold, 0.05);
   if (simulation_frequency <= 0)
   {
     ROS_WARN_STREAM("Simulation frequency (currently " << simulation_frequency
                                                        << ") should be greater than 0. Setting to 1 for now.");
     simulation_frequency = 1;
   }
-  controller_ = std::unique_ptr<SmoothControl>(new SmoothControl{
-      k1, k2, axle_length, simulation_frequency, target_velocity, lookahead_dist, simulation_horizon });
+  controller_ = std::unique_ptr<SmoothControl>(new SmoothControl{ k1, k2, axle_length, simulation_frequency,
+                                                                  target_velocity, lookahead_dist, simulation_horizon,
+                                                                  target_reached_distance, target_move_threshold });
 
   // load global parameters
   igvc::getParam(pNh, "maximum_vel", maximum_vel_);

--- a/igvc_navigation/src/path_follower/path_follower.h
+++ b/igvc_navigation/src/path_follower/path_follower.h
@@ -20,6 +20,7 @@ private:
   ros::Publisher cmd_pub_;
   ros::Publisher target_pub_;
   ros::Publisher trajectory_pub_;
+  ros::Publisher smoothed_pub_;
 
   nav_msgs::PathConstPtr path_;
   geometry_msgs::PointStampedConstPtr waypoint_;

--- a/igvc_navigation/src/path_follower/smooth_control.h
+++ b/igvc_navigation/src/path_follower/smooth_control.h
@@ -104,7 +104,7 @@ private:
    * @return the target position
    */
   RobotState getTargetPosition(const nav_msgs::PathConstPtr& path, const RobotState& state,
-                                              const std::optional<RobotState>& target) const;
+                                              const std::optional<RobotState>& target, size_t path_index) const;
 
   /**
    * Acquires a new target which is lookahead_dist_ away from the current position, interpolating between points
@@ -113,14 +113,14 @@ private:
    * @param state current state of the robot
    * @return the newly acquired target position
    */
-  RobotState acquireNewTarget(const nav_msgs::PathConstPtr& path, const RobotState& state) const;
+  RobotState acquireNewTarget(const nav_msgs::PathConstPtr& path, const RobotState& state, size_t state_index) const;
 
   /**
    * Finds the point closest to the old target on the current path. If the distance is greater
    * than new_target_threshold_, std::nullopt is returned.
    * @return the found target if within the threshold, or std::nullopt
    */
-  std::optional<RobotState> findTargetOnPath(const nav_msgs::PathConstPtr& path, const RobotState& target) const;
+  size_t findTargetOnPath(const nav_msgs::PathConstPtr& path, const RobotState& target) const;
 
   /**
    * Finds the distance along the path provided from the current state to the target state
@@ -129,7 +129,9 @@ private:
    * @param target the target state
    * @return the distance from the current state to the target state along the given path
    */
-  double distAlongPath(const nav_msgs::PathConstPtr& path, const RobotState& state, const RobotState& target) const;
+  double distAlongPath(const nav_msgs::PathConstPtr& path, size_t path_index, size_t target_index) const;
+
+  size_t getClosestIndex(const nav_msgs::PathConstPtr& path, const RobotState& state) const;
 
   /**
    * Converts velocity and angular velocity to left and right wheel velocities

--- a/igvc_navigation/src/path_follower/smooth_control.h
+++ b/igvc_navigation/src/path_follower/smooth_control.h
@@ -33,7 +33,8 @@ class SmoothControl
 {
 public:
   SmoothControl(double k1, double k2, double axle_length, double simulation_frequency, double target_velocity,
-                double m_lookahead_dist, double simulation_horizon, double target_reached_distance, double target_move_threshold);
+                double m_lookahead_dist, double simulation_horizon, double target_reached_distance,
+                double target_move_threshold);
   /**
    * Generate an immediate velocity command and visualize a smooth control trajectory
    * using the procedure described in 'A Smooth Control Law for Graceful Motion of
@@ -101,16 +102,18 @@ private:
    * @param[in] path path to get target position from
    * @param[in] path_index index of closest position along the path relative to current position
    * @param[in] state current state of the robot
+   * @param[in] path_index the index of the closest point on the path to the current state
    * @return the target position
    */
   RobotState getTargetPosition(const nav_msgs::PathConstPtr& path, const RobotState& state,
-                                              const std::optional<RobotState>& target, size_t path_index) const;
+                               const std::optional<RobotState>& target, size_t path_index) const;
 
   /**
    * Acquires a new target which is lookahead_dist_ away from the current position, interpolating between points
    * on the path
-   * @param path path from which to find a target position
-   * @param state current state of the robot
+   * @param[in] path path from which to find a target position
+   * @param[in] state current state of the robot
+   * @param[in] state_index the index of the closest point on the path to the current state
    * @return the newly acquired target position
    */
   RobotState acquireNewTarget(const nav_msgs::PathConstPtr& path, const RobotState& state, size_t state_index) const;
@@ -131,6 +134,12 @@ private:
    */
   double distAlongPath(const nav_msgs::PathConstPtr& path, size_t path_index, size_t target_index) const;
 
+  /**
+   * Returns the closest point on the path to the given state
+   * @param path path to find closest point on
+   * @param state state to find closest point on path for
+   * @return the index of the path which is closest to the state.
+   */
   size_t getClosestIndex(const nav_msgs::PathConstPtr& path, const RobotState& state) const;
 
   /**

--- a/igvc_navigation/src/path_follower/smooth_control.h
+++ b/igvc_navigation/src/path_follower/smooth_control.h
@@ -96,8 +96,7 @@ private:
   bool reachedTarget(const RobotState& state, const RobotState& target) const;
 
   /**
-   * Find the furthest point along trajectory which is lookahead_dist_ away from the current position, interpolating
-   * between points, which is the target position.
+   * Find the furthest point along trajectory which is at least lookahead_dist_ away from the current position.
    *
    * @param[in] path path to get target position from
    * @param[in] path_index index of closest position along the path relative to current position

--- a/igvc_utils/include/igvc_utils/RobotState.hpp
+++ b/igvc_utils/include/igvc_utils/RobotState.hpp
@@ -24,6 +24,14 @@ public:
     setState(msg);
   }
 
+  explicit RobotState(const geometry_msgs::PoseStamped &msg)
+    : x{ msg.pose.position.x }, y{ msg.pose.position.y }
+  {
+    tf::Quaternion quaternion;
+    tf::quaternionMsgToTF(msg.pose.orientation, quaternion);
+    tf::Matrix3x3(quaternion).getRPY(roll, pitch, yaw);
+  }
+
   explicit RobotState(double x, double y, double yaw) : x{ x }, y{ y }, yaw{ yaw }
   {
   }

--- a/igvc_utils/include/igvc_utils/RobotState.hpp
+++ b/igvc_utils/include/igvc_utils/RobotState.hpp
@@ -24,8 +24,7 @@ public:
     setState(msg);
   }
 
-  explicit RobotState(const geometry_msgs::PoseStamped &msg)
-    : x{ msg.pose.position.x }, y{ msg.pose.position.y }
+  explicit RobotState(const geometry_msgs::PoseStamped &msg) : x{ msg.pose.position.x }, y{ msg.pose.position.y }
   {
     tf::Quaternion quaternion;
     tf::quaternionMsgToTF(msg.pose.orientation, quaternion);


### PR DESCRIPTION
This PR changes the path follower to path to "mini-waypoints" within the path instead of pathing towards a constantly moving target (which may not guarantee Lyapunov stability), addressing #365, as well as smoothing the path generated by taking the midpoints only, so that sharp turns are made to be more gradual.

![example_old](https://user-images.githubusercontent.com/4125463/54802067-1c6c7a80-4c40-11e9-97ec-6e56747c656c.png)
Example scenario where the old path planner doesn't really converge on the path.
<br/>
![example_new](https://user-images.githubusercontent.com/4125463/54802069-1e363e00-4c40-11e9-91e9-21890056c6d9.png)
Same scenario, but with the new planner, which does converge onto the path.