### PR TITLE
Add Support for Two Additional Logitech C920 Cameras

### DIFF
--- a/igvc_platform/launch/camera.launch
+++ b/igvc_platform/launch/camera.launch
@@ -2,7 +2,7 @@
 <!-- Usage: "roslaunch igvc_platform camera.launch camera:=[left,right,center]" -->
 <launch>
 	<arg name="camera" default="center" />
-	
+
 	<group if="$(eval 'center' in arg('camera'))">
 		<node name="usb_cam_center" pkg="usb_cam" type="usb_cam_node">
 		    <param name="path" type="string" value="file://$(find igvc_platform)/../../../"/>
@@ -11,6 +11,7 @@
 		    <param name="camera_frame_id" type="string" value="/usb_cam_center" />
 	 	    <param name="camera_info_url" type="string" value="file://$(find igvc_platform)/../sandbox/camera_config/usb_cam_center.yaml" />
 		    <param name="camera_name" type="string" value="usb_cam_center" />
+			<param name="framerate" value="30" />
 		</node>
 	</group>
 
@@ -22,6 +23,7 @@
 		    <param name="camera_frame_id" type="string" value="/usb_cam_right" />
 	 	    <param name="camera_info_url" type="string" value="file://$(find igvc_platform)/../sandbox/camera_config/usb_cam_right.yaml" />
 		    <param name="camera_name" type="string" value="usb_cam_right" />
+			<param name="framerate" value="30" />
 		</node>
 	</group>
 
@@ -33,9 +35,10 @@
 		    <param name="camera_frame_id" type="string" value="/usb_cam_left" />
 	 	    <param name="camera_info_url" type="string" value="file://$(find igvc_platform)/../sandbox/camera_config/usb_cam_left.yaml" />
 		    <param name="camera_name" type="string" value="usb_cam_left" />
+			<param name="framerate" value="30" />
 		</node>
 	</group>
 
 
-	
+
 </launch>

--- a/igvc_platform/launch/sensors.launch
+++ b/igvc_platform/launch/sensors.launch
@@ -13,9 +13,9 @@
     <!-- GPS -->
     <include file="$(find igvc_platform)/launch/gps.launch" />
 
-    <!-- CAMERA -->
+    <!-- LEFT, MIDDLE, & RIGHT CAMERAS (Logitech C920) -->
     <include file="$(find igvc_platform)/launch/camera.launch">
-        <arg name="camera" value="center" />
+        <arg name="camera" value="[left,center,right]" />
     </include>
 
     <!-- LIDAR -->

--- a/igvc_utils/launch/rosbag.launch
+++ b/igvc_utils/launch/rosbag.launch
@@ -7,5 +7,5 @@
     -->
 <launch>
     <node pkg="rosbag" type="record" name="record" output="screen"
-          args="-a -x '(.*)image(.*)*' -e '(.*)/image_raw/compressed' -o $(env HOME)/data/$(env CHASSIS_NAME)_$(env LOCATION)" />
+          args="-a -x '(.*)image(.*)*' usb_cam_center/image_raw/compressed usb_cam_left/image_raw/compressed usb_cam_right/image_raw/compressed -o $(env HOME)/data/$(env CHASSIS_NAME)_$(env LOCATION)" />
 </launch>

--- a/sandbox/igvc.rules
+++ b/sandbox/igvc.rules
@@ -1,8 +1,11 @@
 SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", ATTRS{bcdDevice}=="1000", SYMLINK+="igvc_lidar", GROUP="plugdev", MODE="0666"
+
 SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001",ATTRS{serial}=="A105BMON", SYMLINK+="igvc_imu"
-KERNEL=="video?", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="0825", ATTRS{bcdDevice}=="0012", ATTRS{serial}=="21AD0B10", SYMLINK+="igvc_usb_cam_right"
-KERNEL=="video?", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="0825", ATTRS{bcdDevice}=="0012", ATTRS{serial}=="DA101B10", SYMLINK+="igvc_usb_cam_left"
+
+KERNEL=="video?", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="082d", ATTRS{bcdDevice}=="0011", ATTRS{serial}=="F6CB206F", SYMLINK+="igvc_usb_cam_right"
+KERNEL=="video?", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="082d", ATTRS{bcdDevice}=="0011", ATTRS{serial}=="EBD81F4F", SYMLINK+="igvc_usb_cam_left"
 KERNEL=="video?", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="082d", ATTRS{bcdDevice}=="0011", ATTRS{serial}=="6E5D96EF", SYMLINK+="igvc_usb_cam_center"
+
 SUBSYSTEM=="tty", ATTRS{idVendor}=="067b", ATTRS{idProduct}=="2303",ATTRS{bcdDevice}=="0400", SYMLINK+="igvc_gps"
 SUBSYSTEM=="tty", ATTRS{idVendor}=="1f00", ATTRS{idProduct}=="2012",ATTRS{bcdDevice}=="0100", SYMLINK+="igvc_motor_board"
 


### PR DESCRIPTION
This PR modifies the udev rules, `igvc_platform`, and `igvc_utils` to add support for two additional left and right facing Logitech C920 cameras:

* Update `igvc.rules` to add correct udev rules for left and right cameras
* Launch the [left,middle,right] cameras in `sensors.launch`
* Record compressed images from left and right cameras in `rosbag.launch`
* Add the parameter `framerate` to `camera.launch` with the default value (30).