### PR TITLE
Fix floating point PID bug

### DIFF
--- a/igvc_platform/launch/motor_controller.launch
+++ b/igvc_platform/launch/motor_controller.launch
@@ -3,8 +3,8 @@
     <node name="motor_controller" pkg="igvc_platform" type="motor_controller" output="screen">
           <param name="ip_addr" type="str" value="192.168.1.20"/>
           <param name="port" type="int" value="7"/>
-          <param name="p_l" type="double" value="30.0"/>
-          <param name="p_r" type="double" value="30.0"/>
+          <param name="p_l" type="double" value="30.1"/>
+          <param name="p_r" type="double" value="30.1"/>
           <param name="d_l" type="double" value="2.0"/>
           <param name="d_r" type="double" value="2.0"/>
           <param name="i_r" type="double" value="0.0"/>

--- a/igvc_platform/src/motor_controller/motor_controller.cpp
+++ b/igvc_platform/src/motor_controller/motor_controller.cpp
@@ -153,9 +153,9 @@ void MotorController::setPID()
       ros::shutdown();
     }
 
-    valid_values = (static_cast<double>(response.p_l) == p_l_) && (static_cast<double>(response.p_r) == p_r_) &&
-                   (static_cast<double>(response.i_l) == i_l_) && (static_cast<double>(response.i_r) == i_r_) &&
-                   (static_cast<double>(response.d_l) == d_l_) && (static_cast<double>(response.d_r) == d_r_);
+    valid_values = (response.p_l == static_cast<float>(p_l_)) && (response.p_r == static_cast<float>(p_r_)) &&
+                   (response.i_l == static_cast<float>(i_l_)) && (response.i_r == static_cast<float>(i_r_)) &&
+                   (response.d_l == static_cast<float>(d_l_)) && (response.d_r == static_cast<float>(d_r_));
 
     rate.sleep();
   }


### PR DESCRIPTION
This PR fixes a bug that causes `motor_controller`'s `setPID()` method to enter an infinite while-loop when the specified PID value is a floating point number.