### PR TITLE
Update gazebo to incorporate recent scan_to_pointcloud changes and add ros_control build dependencies

### DIFF
--- a/igvc_gazebo/launch/gazebo.launch
+++ b/igvc_gazebo/launch/gazebo.launch
@@ -36,6 +36,7 @@
   <node name="scan_to_pointcloud" pkg="igvc_gazebo" type="scan_to_pointcloud" output="screen" >
     <param name="min_dist" value="0.1"/>
     <param name="neighbor_dist" value="0.2"/>
+    <param name="offset" value="0"/>
   </node>
   <include file="$(find igvc_description)/launch/spawn_jaymii.launch" />
   <include file="$(find igvc_perception)/launch/filter_lidar.launch" />

--- a/igvc_gazebo/package.xml
+++ b/igvc_gazebo/package.xml
@@ -27,6 +27,10 @@
   <build_depend>gazebo_ros</build_depend>
   <build_depend>joint_state_controller</build_depend>
   <build_depend>effort_controllers</build_depend>
+  <build_depend>ros_control</build_depend>
+  <build_depend>gazebo_ros_pkgs</build_depend>
+
+
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>roscpp</run_depend>
@@ -42,4 +46,6 @@
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>roslib</run_depend>
   <run_depend>gazebo_ros</run_depend>
+  <run_depend>ros_control</run_depend>
+  <run_depend>gazebo_ros_pkgs</run_depend>
 </package>


### PR DESCRIPTION
This PR updates `igvc_gazebo` by:

* adding an `offset` parameter to `gazebo.launch` to adapt to the recently-made changes in `scan_to_pointcloud`
* updating the `package.xml` with a `<build_depend>` on `ros_control`