### PR TITLE
Bug with tilted lidar transform in mapper

### DIFF
--- a/igvc_navigation/src/mapper/mapper.cpp
+++ b/igvc_navigation/src/mapper/mapper.cpp
@@ -103,6 +103,7 @@ void Mapper::insertLidarScan(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr& pc,
 
       MapUtils::getEmptyPoints(nonground_lidar, empty_pc, angular_resolution_, empty_filter_options_);
       pcl_ros::transformPointCloud(empty_pc, empty_pc, lidar_to_odom);
+      MapUtils::projectTo2D(empty_pc);
 
       MapUtils::debugPublishPointCloud(empty_pc_pub_, empty_pc, pc->header.stamp, "/odom", debug_);
     }


### PR DESCRIPTION
This PR fixes a bug in the mapper when the lidar transform is tilted, as is the case in #359.