### PR TITLE
Hotfix/joystick test bug

### DIFF
--- a/igvc_platform/src/tests/test_joystick_driver.cpp
+++ b/igvc_platform/src/tests/test_joystick_driver.cpp
@@ -52,7 +52,7 @@ TEST_F(TestJoystickDriver, FullForward)
   mock_joy_pub.publish(joy_msg);
 
   const igvc_msgs::velocity_pair::ConstPtr response =
-      ros::topic::waitForMessage<igvc_msgs::velocity_pair>(motor_sub.getTopic(), ros::Duration(1));
+      ros::topic::waitForMessage<igvc_msgs::velocity_pair>(motor_sub.getTopic(), ros::Duration(10));
 
   EXPECT_TRUE(response.get() != nullptr);
   EXPECT_EQ(response->left_velocity, 1.0);
@@ -67,7 +67,7 @@ TEST_F(TestJoystickDriver, FullReverse)
   mock_joy_pub.publish(joy_msg);
 
   const igvc_msgs::velocity_pair::ConstPtr response =
-      ros::topic::waitForMessage<igvc_msgs::velocity_pair>(motor_sub.getTopic(), ros::Duration(1));
+      ros::topic::waitForMessage<igvc_msgs::velocity_pair>(motor_sub.getTopic(), ros::Duration(10));
 
   EXPECT_TRUE(response.get() != nullptr);
   EXPECT_EQ(response->left_velocity, -1.0);
@@ -82,7 +82,7 @@ TEST_F(TestJoystickDriver, SpinRight)
   mock_joy_pub.publish(joy_msg);
 
   const igvc_msgs::velocity_pair::ConstPtr response =
-      ros::topic::waitForMessage<igvc_msgs::velocity_pair>(motor_sub.getTopic(), ros::Duration(1));
+      ros::topic::waitForMessage<igvc_msgs::velocity_pair>(motor_sub.getTopic(), ros::Duration(10));
 
   EXPECT_TRUE(response.get() != nullptr);
   EXPECT_EQ(response->left_velocity, 1.0);
@@ -97,7 +97,7 @@ TEST_F(TestJoystickDriver, SpinLeft)
   mock_joy_pub.publish(joy_msg);
 
   const igvc_msgs::velocity_pair::ConstPtr response =
-      ros::topic::waitForMessage<igvc_msgs::velocity_pair>(motor_sub.getTopic(), ros::Duration(1));
+      ros::topic::waitForMessage<igvc_msgs::velocity_pair>(motor_sub.getTopic(), ros::Duration(10));
 
   EXPECT_TRUE(response.get() != nullptr);
   EXPECT_EQ(response->left_velocity, -1.0);
@@ -112,7 +112,7 @@ TEST_F(TestJoystickDriver, HalfSpeedForward)
   mock_joy_pub.publish(joy_msg);
 
   const igvc_msgs::velocity_pair::ConstPtr response =
-      ros::topic::waitForMessage<igvc_msgs::velocity_pair>(motor_sub.getTopic(), ros::Duration(1));
+      ros::topic::waitForMessage<igvc_msgs::velocity_pair>(motor_sub.getTopic(), ros::Duration(10));
 
   EXPECT_TRUE(response.get() != nullptr);
   EXPECT_EQ(response->left_velocity, 0.5);


### PR DESCRIPTION
This PR increases the timeout duration for `waitForMessage` from 1 to 10 seconds in the joystick tests. The hypothesis is that the CI server got slower, which is why we are non-deterministically failing the joystick tests.