### PR TITLE
Gazebo PID and fixes

### DIFF
--- a/igvc_description/urdf/jessii.urdf.xacro
+++ b/igvc_description/urdf/jessii.urdf.xacro
@@ -23,7 +23,7 @@
 
   <!-- wheel acuator limits -->
   <xacro:property name="drive_wheel_eff_limit" value="8"/>
-  <xacro:property name="drive_wheel_vel_limit" value="20"/>
+  <xacro:property name="drive_wheel_vel_limit" value="10"/>
 
   <!-- drive shock params-->
   <!-- how far the drive wheel shock can move (m)-->

--- a/igvc_description/urdf/worlds/qualification.world
+++ b/igvc_description/urdf/worlds/qualification.world
@@ -151,8 +151,8 @@
       <pose>-10 -20 0 0 -0 0</pose>
     </include>
     <physics type="ode">
-      <max_step_size>0.00025</max_step_size>
-      <real_time_update_rate>5000</real_time_update_rate>
+      <max_step_size>0.0005</max_step_size>
+      <real_time_update_rate>2000</real_time_update_rate>
     </physics>
   </world>
 </sdf>

--- a/igvc_description/urdf/worlds/qualification.world
+++ b/igvc_description/urdf/worlds/qualification.world
@@ -150,5 +150,9 @@
       <name>construction_barrel_25</name> <!-- THE NAME MUST BE UNIQUE-->
       <pose>-10 -20 0 0 -0 0</pose>
     </include>
+    <physics type="ode">
+      <max_step_size>0.00025</max_step_size>
+      <real_time_update_rate>5000</real_time_update_rate>
+    </physics>
   </world>
 </sdf>

--- a/igvc_gazebo/launch/igvc_control.launch
+++ b/igvc_gazebo/launch/igvc_control.launch
@@ -11,14 +11,14 @@
 
   <node name="igvc_control" pkg="igvc_gazebo" type="control" output="screen">
       <!-- PID values for wheel speed -->
-      <param name="speed_P_left" value="0.2"/>
-      <param name="speed_P_right" value="0.2"/>
-      <param name="speed_D_left" value="0.1"/>
-      <param name="speed_D_right" value="0.1"/>
+      <param name="speed_P_left" value="2.0"/>
+      <param name="speed_P_right" value="2.0"/>
+      <param name="speed_D_left" value="0.3"/>
+      <param name="speed_D_right" value="0.3"/>
       <param name="speed_I_left" value="0.000"/>
       <param name="speed_I_right" value="0.000"/>
       <param name="wheel_radius" value="0.3429"/>
-      <param name="max_effort" value="4.5"/>
+      <param name="max_effort" value="8.0"/>
       <param name="rate" value="60.0"/>
   </node>
 

--- a/igvc_gazebo/launch/qualification.launch
+++ b/igvc_gazebo/launch/qualification.launch
@@ -10,7 +10,7 @@
 
   <!-- Vehicle pose -->
   <arg name="x" value="-30"/>
-  <arg name="z" value="0.5"/>
+  <arg name="z" value="0.1525"/>
   <arg name="roll" value="0.0"/>
   <arg name="pitch" value="0.0"/>
   <arg name="yaw" value="0"/>


### PR DESCRIPTION
This PR updates the PID coefficients to have a step response of around 0.5s as opposed to 1s.
![step_response](https://user-images.githubusercontent.com/4125463/56553177-96539480-655b-11e9-8c12-6f399340330f.png)

Also, maximum effort was updated.

The starting location of the robot is also changed from somewhere midair to decently on the ground.
