### PR TITLE
Fix for lidar points within the minimum lidar range

### DIFF
--- a/igvc_navigation/launch/mapper.launch
+++ b/igvc_navigation/launch/mapper.launch
@@ -2,7 +2,7 @@
     <!--<include file="$(find igvc_navigation)/launch/localization.launch" />-->
 
     <!-- Map Node -->
-    <node name="mapper" pkg="igvc_navigation" type="mapper" output="screen">
+    <node name="mapper" pkg="igvc_navigation" type="mapper" output="screen" >
             <rosparam command="load" file="$(find igvc_navigation)/launch/octomap.yaml"/>
     </node>
 

--- a/igvc_navigation/launch/octomap.yaml
+++ b/igvc_navigation/launch/octomap.yaml
@@ -29,6 +29,7 @@ filters:
         enabled: true
         start_angle: -0.5 #Radians
         end_angle: 0.5
+        ray_start_distance: 1
         miss_cast_distance: 5
         max_range: 5
     empty_image: # Blur and threshold for determining which points in the segmented image are empty space

--- a/igvc_navigation/src/mapper/map_utils.h
+++ b/igvc_navigation/src/mapper/map_utils.h
@@ -23,6 +23,7 @@ struct EmptyFilterOptions
   bool enabled;
   radians start_angle;
   radians end_angle;
+  double ray_start_distance;
   double miss_cast_distance;
   double max_range;
 };
@@ -62,6 +63,8 @@ struct GroundPlane
   double d;
 };
 
+class Ray;
+
 namespace MapUtils
 {
 using radians = double;
@@ -83,7 +86,8 @@ int discretize(radians angle, double angular_resolution);
  * @param[in] angular_resolution angular resolution to use in filter
  * @param[in] options Parameters to use for the filter
  */
-void getEmptyPoints(const PointCloud& pc, PointCloud& empty_pc, double angular_resolution, EmptyFilterOptions options);
+void getEmptyPoints(const PointCloud& pc, std::vector<Ray>& empty_rays, double angular_resolution,
+                    EmptyFilterOptions options);
 
 /**
  * Filters points behind the robot

--- a/igvc_navigation/src/mapper/map_utils.h
+++ b/igvc_navigation/src/mapper/map_utils.h
@@ -79,10 +79,10 @@ using PointCloud = pcl::PointCloud<pcl::PointXYZ>;
 int discretize(radians angle, double angular_resolution);
 
 /**
- * Returns a pcl::PointCloud of points which have not been detected by the lidar scan, according to the angular
+ * Returns a std::vector of Rays which have not been detected by the lidar scan, according to the angular
  * resolution
  * @param[in] pc lidar scan
- * @param[out] empty_pc points that are found to be free
+ * @param[out] empty_rays points that are found to be free
  * @param[in] angular_resolution angular resolution to use in filter
  * @param[in] options Parameters to use for the filter
  */

--- a/igvc_navigation/src/mapper/mapper.cpp
+++ b/igvc_navigation/src/mapper/mapper.cpp
@@ -125,9 +125,6 @@ void Mapper::insertLidarScan(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr& pc,
       pcl_ros::transformPointCloud(nonground, nonground_lidar, lidar_to_odom.inverse());
 
       empty_rays = getTransformedEmptyRays(nonground_lidar, lidar_to_odom);
-
-      MapUtils::debugPublishPointCloud(empty_pc_pub_, empty_pc, pc->header.stamp, "/odom",
-                                       debug_pub_filtered_pointclouds);
     }
 
     octomapper_->insertScan(lidar_to_odom.getOrigin(), pc_map_pair_, nonground, lidar_scan_probability_model_, radius_);
@@ -237,13 +234,15 @@ std::vector<Ray> Mapper::getTransformedEmptyRays(const PointCloud& nonground, co
     ray.end.z = 0;
   });
 
-  PointCloud empty_pc{};
-  std::for_each(empty_rays.begin(), empty_rays.end(), [&](Ray& ray) {
-    empty_pc.points.emplace_back(pcl::PointXYZ{ ray.end.x, ray.end.y, ray.end.z });
-  });
+  if (debug_pub_filtered_pointclouds)\
+  {
+    PointCloud empty_pc{};
+    std::for_each(empty_rays.begin(), empty_rays.end(), [&](Ray& ray) {
+      empty_pc.points.emplace_back(pcl::PointXYZ{ ray.end.x, ray.end.y, ray.end.z });
+    });
 
-  MapUtils::debugPublishPointCloud(empty_pc_pub_, empty_pc, nonground.header.stamp, "/odom", debug_);
-
+    MapUtils::debugPublishPointCloud(empty_pc_pub_, empty_pc, nonground.header.stamp, "/odom", debug_pub_filtered_pointclouds);
+  }
   return empty_rays;
 }
 

--- a/igvc_navigation/src/mapper/mapper.cpp
+++ b/igvc_navigation/src/mapper/mapper.cpp
@@ -137,12 +137,12 @@ void Mapper::insertLidarScan(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr& pc,
 
     if (empty_filter_options_.enabled)
     {
-//      MapUtils::getEmptyPoints(*pc, empty_pc, angular_resolution_, empty_filter_options_);
-//      pcl_ros::transformPointCloud(empty_pc, empty_pc, lidar_to_odom);
-//
-//      MapUtils::projectTo2D(empty_pc);
-//      MapUtils::debugPublishPointCloud(empty_pc_pub_, empty_pc, pc->header.stamp, "/odom",
-//                                       debug_pub_filtered_pointclouds);
+      //      MapUtils::getEmptyPoints(*pc, empty_pc, angular_resolution_, empty_filter_options_);
+      //      pcl_ros::transformPointCloud(empty_pc, empty_pc, lidar_to_odom);
+      //
+      //      MapUtils::projectTo2D(empty_pc);
+      //      MapUtils::debugPublishPointCloud(empty_pc_pub_, empty_pc, pc->header.stamp, "/odom",
+      //                                       debug_pub_filtered_pointclouds);
       empty_rays = getTransformedEmptyRays(*pc, lidar_to_odom);
     }
   }
@@ -234,14 +234,15 @@ std::vector<Ray> Mapper::getTransformedEmptyRays(const PointCloud& nonground, co
     ray.end.z = 0;
   });
 
-  if (debug_pub_filtered_pointclouds)\
+  if (debug_pub_filtered_pointclouds)
   {
     PointCloud empty_pc{};
     std::for_each(empty_rays.begin(), empty_rays.end(), [&](Ray& ray) {
       empty_pc.points.emplace_back(pcl::PointXYZ{ ray.end.x, ray.end.y, ray.end.z });
     });
 
-    MapUtils::debugPublishPointCloud(empty_pc_pub_, empty_pc, nonground.header.stamp, "/odom", debug_pub_filtered_pointclouds);
+    MapUtils::debugPublishPointCloud(empty_pc_pub_, empty_pc, nonground.header.stamp, "/odom",
+                                     debug_pub_filtered_pointclouds);
   }
   return empty_rays;
 }

--- a/igvc_navigation/src/mapper/mapper.h
+++ b/igvc_navigation/src/mapper/mapper.h
@@ -100,6 +100,8 @@ private:
    */
   void invertMissProbabilities();
 
+  std::vector<Ray> getTransformedEmptyRays(const PointCloud& nonground, const tf::Transform& lidar_to_odom);
+
   std::unique_ptr<Octomapper> octomapper_;
   pc_map_pair pc_map_pair_;      // Struct storing both the octomap for the lidar and the cv::Mat map
   pc_map_pair camera_map_pair_;  // Struct storing both the octomap for the camera projections and the cv::Mat map

--- a/igvc_navigation/src/mapper/octomapper.cpp
+++ b/igvc_navigation/src/mapper/octomapper.cpp
@@ -45,6 +45,11 @@ void PCL_to_Octomap(const pcl::PointCloud<pcl::PointXYZ> &pcl, octomap::Pointclo
   octomap::pointCloud2ToOctomap(pc2, octo);
 }
 
+octomap::point3d PCL_to_OctomapPoint(const pcl::PointXYZ &pcl)
+{
+  return { pcl.x, pcl.y, pcl.z };
+}
+
 uchar toCharProb(float p)
 {
   return static_cast<uchar>(p * 255);
@@ -146,7 +151,7 @@ void Octomapper::insertScan(const tf::Point &sensor_pos, struct pc_map_pair &pai
   pair.octree->setProbMiss(old_prob_miss);
 }
 
-void Octomapper::insertRays(const tf::Point &sensor_pos, struct pc_map_pair &pair, const PointCloud &pc, bool occupied,
+void Octomapper::insertRays(const tf::Point &sensor_pos, pc_map_pair &pair, const PointCloud &pc, bool occupied,
                             ProbabilityModel model) const
 {
   double old_prob_hit = pair.octree->getProbHit();
@@ -166,6 +171,39 @@ void Octomapper::insertRays(const tf::Point &sensor_pos, struct pc_map_pair &pai
   {
     octomap::KeyRay keyray;
     if (pair.octree->computeRayKeys(sensor, p, keyray))
+    {
+      {
+        keyset.insert(keyray.begin(), keyray.end());
+      }
+    }
+  }
+
+  for (const auto &key : keyset)
+  {
+    pair.octree->updateNode(key, occupied, false);
+  }
+
+  pair.octree->setProbHit(old_prob_hit);
+  pair.octree->setProbMiss(old_prob_miss);
+}
+
+void Octomapper::insertRaysWithStartPoint(pc_map_pair &pair, const std::vector<Ray> &pc_rays, bool occupied,
+                                          ProbabilityModel model) const
+{
+  // TODO(Oswin): Change this to RAII like thing
+  double old_prob_hit = pair.octree->getProbHit();
+  double old_prob_miss = pair.octree->getProbMiss();
+  pair.octree->setProbHit(model.prob_hit);
+  pair.octree->setProbMiss(model.prob_miss);
+
+  octomap::KeySet keyset{};
+
+  for (const Ray &ray : pc_rays)
+  {
+    octomap::point3d start = PCL_to_OctomapPoint(ray.start);
+    octomap::point3d end = PCL_to_OctomapPoint(ray.end);
+    octomap::KeyRay keyray;
+    if (pair.octree->computeRayKeys(start, end, keyray))
     {
       {
         keyset.insert(keyray.begin(), keyray.end());

--- a/igvc_navigation/src/mapper/octomapper.h
+++ b/igvc_navigation/src/mapper/octomapper.h
@@ -54,6 +54,12 @@ struct OcTreeOptions
   double min;
 };
 
+struct Ray
+{
+  pcl::PointXYZ start;
+  pcl::PointXYZ end;
+};
+
 /**
  * Struct representing options for the map.
  * Length and Width are both in m, not grid cells.
@@ -140,6 +146,17 @@ public:
    */
   void insertRays(const tf::Point& sensor_pos, struct pc_map_pair& pair, const PointCloud& pc, bool occupied,
                   ProbabilityModel model) const;
+
+  /**
+   * Inserts a ray into the given pc_map_pair, where each ray has a start and end position, with the points in the ray
+   * marked as either occupied or not occupied, and the probabilities used depending on the ProbabilityModel passed in
+   * @param pair
+   * @param pc_rays
+   * @param occupied
+   * @param model
+   */
+  void insertRaysWithStartPoint(pc_map_pair& pair, const std::vector<Ray>& pc_rays, bool occupied,
+                                ProbabilityModel model) const;
 
   /**
    * Inserts the passed in points to the given pc_map_pair, where the points are either occupied or not depending


### PR DESCRIPTION
This PR fixes #406 by creating a `ray_start_distance` option that changes the start distance for the raycasted, as points that are inside the distance for filtering are not accounted for in the sensor model right now.