### PR TITLE
Flipped probabilities for camera free space

### DIFF
--- a/igvc_navigation/launch/octomap.yaml
+++ b/igvc_navigation/launch/octomap.yaml
@@ -15,7 +15,7 @@ probability_model:
         free_space: # Rays that are not detected by the lidar to have occupied points along them
             prob_miss: 0.52
     camera:
-        prob_miss: 0.45
+        prob_miss: 0.51
         prob_hit: 0.9
 sensor_model:
     max_range: 5


### PR DESCRIPTION
This PR changes the probability for camera free space from <0.5 to >0.5, so that free space correctly registers as unoccupied.