### PR TITLE
Disabling free space detection on blocked parts of the image

### DIFF
--- a/igvc_navigation/launch/octomap.yaml
+++ b/igvc_navigation/launch/octomap.yaml
@@ -49,7 +49,7 @@ filters:
             plane_distance: 0.04 # +-m from z=0
     remove_occupied:
         enable: true
-        kernel_size: 50
+        kernel_size: 70
 map:
     # In units of meters, not cells
     # width of grid = width / resolution

--- a/igvc_navigation/launch/octomap.yaml
+++ b/igvc_navigation/launch/octomap.yaml
@@ -47,6 +47,9 @@ filters:
             eps_angle: 0.5
         fallback:
             plane_distance: 0.04 # +-m from z=0
+    remove_occupied:
+        enable: true
+        kernel_size: 50
 map:
     # In units of meters, not cells
     # width of grid = width / resolution

--- a/igvc_navigation/src/mapper/map_utils.cpp
+++ b/igvc_navigation/src/mapper/map_utils.cpp
@@ -179,27 +179,27 @@ void removeOccupiedFromImage(cv::Mat& image, const PointCloud& last_scan,
   cv::Mat projected_image(image.size().height, image.size().width, image.type(), static_cast<uchar>(0));
 
   std::vector<cv::Point2d> projected_points;
-  projected_points.reserve(100);
+  projected_points.reserve(last_scan.points.size());
 
   // Transform pointcloud to image frame, add if inside image
   for (const auto& point : last_scan.points)
   {
-    tf::Vector3 transformed = odom_to_camera * tf::Vector3{ point.x, point.y, 0 };
+    tf::Vector3 transformed = odom_to_camera * tf::Vector3{ point.x, point.y, point.z };
     cv::Point3d cv_point{ transformed.x(), transformed.y(), transformed.z() };
     cv::Point2d projected_point = camera_model.project3dToPixel(cv_point);
     if (projected_point.inside(image_rect))
     {
       projected_points.emplace_back(projected_point);
-      for (int i = 0; i < 10; i++)
-      {
-        tf::Vector3 transformed_heights = odom_to_camera * tf::Vector3{ point.x, point.y, i * 0.1 };
-        cv::Point3d cv_point_heights{ transformed_heights.x(), transformed_heights.y(), transformed_heights.z() };
-        cv::Point2d projected_point_heights = camera_model.project3dToPixel(cv_point_heights);
-        if (projected_point_heights.inside(image_rect))
-        {
-          projected_points.emplace_back(projected_point_heights);
-        }
-      }
+      //      for (int i = 0; i < 10; i++)
+      //      {
+      //        tf::Vector3 transformed_heights = odom_to_camera * tf::Vector3{ point.x, point.y, i * 0.1 };
+      //        cv::Point3d cv_point_heights{ transformed_heights.x(), transformed_heights.y(), transformed_heights.z()
+      //        }; cv::Point2d projected_point_heights = camera_model.project3dToPixel(cv_point_heights); if
+      //        (projected_point_heights.inside(image_rect))
+      //        {
+      //          projected_points.emplace_back(projected_point_heights);
+      //        }
+      //      }
     }
   }
 

--- a/igvc_navigation/src/mapper/map_utils.h
+++ b/igvc_navigation/src/mapper/map_utils.h
@@ -57,7 +57,7 @@ struct GroundFilterOptions
 struct RemoveOccupiedOptions
 {
   bool enable;
-  double kernel_size;
+  int kernel_size;
 };
 
 struct GroundPlane

--- a/igvc_navigation/src/mapper/map_utils.h
+++ b/igvc_navigation/src/mapper/map_utils.h
@@ -54,6 +54,12 @@ struct GroundFilterOptions
   FallbackOptions fallback_options;
 };
 
+struct RemoveOccupiedOptions
+{
+  bool enable;
+  double kernel_size;
+};
+
 struct GroundPlane
 {
   double a;
@@ -90,7 +96,6 @@ void getEmptyPoints(const PointCloud& pc, PointCloud& empty_pc, double angular_r
  * @param[in] pc lidar scan
  * @param[out] filtered_pc filtered pointcloud
  */
-
 void filterPointsBehind(const PointCloud& pc, PointCloud& filtered_pc, BehindFilterOptions options);
 
 /**
@@ -126,6 +131,10 @@ std::optional<GroundPlane> ransacFilter(const PointCloud& raw_pc, PointCloud& gr
  */
 void fallbackFilter(const PointCloud& raw_pc, PointCloud& ground, PointCloud& nonground,
                     const FallbackOptions& options);
+
+void removeOccupiedFromImage(cv::Mat& image, const PointCloud& last_scan,
+                             const image_geometry::PinholeCameraModel& camera_model,
+                             const tf::Transform& camera_to_odom, const RemoveOccupiedOptions& options);
 
 /**
  * Projects all black pixels (0, 0, 0) in the image to the ground plane and inserts them into the pointcloud
@@ -165,6 +174,7 @@ inline bool withinRange(const pcl::PointXYZ& point, double range);
 
 void debugPublishPointCloud(const ros::Publisher& publisher, pcl::PointCloud<pcl::PointXYZ>& pointcloud,
                             const uint64 stamp, std::string&& frame, bool debug);
+void debugPublishImage(const ros::Publisher& publisher, const cv::Mat& image, const ros::Time stamp, bool debug);
 }  // namespace MapUtils
 
 inline bool MapUtils::withinRange(const pcl::PointXYZ& point, double range)

--- a/igvc_navigation/src/mapper/mapper.cpp
+++ b/igvc_navigation/src/mapper/mapper.cpp
@@ -170,9 +170,9 @@ void Mapper::insertSegmentedImage(cv::Mat&& image, const tf::Transform& base_to_
     {
       MapUtils::removeOccupiedFromImage(image, last_scan_, camera_model_, base_to_odom * camera_to_base,
                                         remove_occupied_options_);
+      MapUtils::debugPublishImage(lidared_image_pub_, image, stamp, debug_);
     }
     MapUtils::projectToPlane(projected_pc, ground_plane_, image, camera_model_, camera_to_base);
-    MapUtils::debugPublishImage(lidared_image_pub_, image, stamp, debug_);
   }
 
   pcl_ros::transformPointCloud(projected_pc, projected_pc, base_to_odom);

--- a/igvc_navigation/src/mapper/mapper.h
+++ b/igvc_navigation/src/mapper/mapper.h
@@ -102,6 +102,7 @@ private:
   BehindFilterOptions behind_filter_options_{};
   ProcessImageOptions process_image_options_{};
   CombinedMapOptions combined_map_options_{};
+  RemoveOccupiedOptions remove_occupied_options_{};
 
   ros::Publisher camera_projection_pub_;
   ros::Publisher filtered_pc_pub_;
@@ -110,6 +111,7 @@ private:
   ros::Publisher nonground_pub_;
   ros::Publisher nonground_projected_pub_;
   ros::Publisher camera_line_pub_;
+  ros::Publisher lidared_image_pub_;
 
   ProbabilityModel lidar_scan_probability_model_{};
   ProbabilityModel lidar_ground_probability_model_{};
@@ -118,6 +120,8 @@ private:
   ProbabilityModel camera_probability_model_{};
   GroundFilterOptions ground_filter_options_{};
   GroundPlane ground_plane_;
+
+  PointCloud last_scan_{};
 
   bool use_ground_filter_;
   bool camera_model_initialized_;


### PR DESCRIPTION
This PR adds a filter to that uses the most recent lidar scan to remove parts of the image from being treated as free space, so that lines that are hidden behind barrels are not treated as free space.