### PR TITLE
Commit streaming slot settings to resolve IMU value-ordering issue

### DIFF
--- a/igvc_platform/launch/imu_top.launch
+++ b/igvc_platform/launch/imu_top.launch
@@ -6,7 +6,7 @@
     <!-- Top IMU -->
     <node pkg="igvc_platform" name="imu_top" type="imu" output="screen" >
         <param name="SERIAL_PORT" type="string" value="/dev/imu_top" />
-        <param name="frame_id" type="string" value="magnetometer"/>
+        <param name="frame_id" type="string" value="imu"/>
         <remap from="imu" to="magnetometer" />
     </node>
 </launch>

--- a/igvc_platform/launch/imu_top.launch
+++ b/igvc_platform/launch/imu_top.launch
@@ -6,7 +6,7 @@
     <!-- Top IMU -->
     <node pkg="igvc_platform" name="imu_top" type="imu" output="screen" >
         <param name="SERIAL_PORT" type="string" value="/dev/imu_top" />
-        <param name="frame_id" type="string" value="imu"/>
+        <param name="frame_id" type="string" value="magnetometer"/>
         <remap from="imu" to="magnetometer" />
     </node>
 </launch>

--- a/igvc_platform/src/imu/YostLabDriver.cpp
+++ b/igvc_platform/src/imu/YostLabDriver.cpp
@@ -144,7 +144,8 @@ void YostLabDriver::run()
   */
   this->SerialWriteString(SET_STREAMING_SLOTS);
 
-  // commit settinga and start streaming!
+  // commit settings and start streaming!
+  this->SerialWriteString(COMMIT_SETTINGS);
   this->SerialWriteString(SET_STREAMING_TIMING_5_MS);
   this->SerialWriteString(START_STREAMING);
 
@@ -152,6 +153,7 @@ void YostLabDriver::run()
 
   int line_num_ = 0;
   sensor_msgs::Imu imu_msg_;
+  imu_msg_.header.seq = 0;
   std::vector<double> parsed_val_;
 
   // orientation correction matrices in 3x3 row-major format and quaternion
@@ -178,6 +180,7 @@ void YostLabDriver::run()
       {
         line_num_ = 0;
         imu_msg_.header.stamp = ros::Time::now();
+        imu_msg_.header.seq++;
         imu_msg_.header.frame_id = frame_id_;
 
         // construct quaternion with (x,y,z,w)


### PR DESCRIPTION
This PR solves the issue encountered during our last field testing day whereby angular velocity and heading values were flipped. Streaming slots are now correctly signaled, ensuring proper access of IMU data. Closes #418 