### PR TITLE
Launch the correct URDF in robot_state_publisher

### DIFF
--- a/igvc_navigation/launch/robot_state_publisher.launch
+++ b/igvc_navigation/launch/robot_state_publisher.launch
@@ -3,6 +3,6 @@
     This file launches the state_publisher node that broadcasts the tf structure of the robot.
     -->
 <launch>
-    <param name="robot_description" command="$(find xacro)/xacro $(find igvc_description)/urdf/jessii.urdf.xacro gpu:=false" />
+    <param name="robot_description" command="$(find xacro)/xacro $(find igvc_description)/urdf/jessii.urdf.xacro" />
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
 </launch>

--- a/igvc_navigation/launch/robot_state_publisher.launch
+++ b/igvc_navigation/launch/robot_state_publisher.launch
@@ -3,6 +3,6 @@
     This file launches the state_publisher node that broadcasts the tf structure of the robot.
     -->
 <launch>
-    <param name="robot_description" command="cat $(find igvc_description)/urdf/jessi.urdf"/>
+    <param name="robot_description" command="$(find xacro)/xacro $(find igvc_description)/urdf/jessii.urdf.xacro gpu:=false" />
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
 </launch>


### PR DESCRIPTION
This PR modifies `robot_state_publisher.launch` to launch `jessii.urdf.xacro`, the most recent and most up-to-date urdf file.