### PR TITLE
Added options to control debug mapper debug topics

### DIFF
--- a/igvc_navigation/launch/octomap.yaml
+++ b/igvc_navigation/launch/octomap.yaml
@@ -80,7 +80,14 @@ frames:
         center: "/center_cam_optical"
         right: "/right_cam_optical"
 node:
-    debug: true
+    debug:
+        publish:
+            map_debug_pcl: true
+            cameras:
+                lines: false
+                projections: false
+            filtered_pointclouds: false
+
     use_lines: true
     camera:
         left:

--- a/igvc_navigation/src/mapper/mapper.h
+++ b/igvc_navigation/src/mapper/mapper.h
@@ -133,7 +133,11 @@ private:
   bool use_ground_filter_;
   bool camera_model_initialized_;
   bool use_lines_;
-  bool debug_;
+
+  bool debug_pub_camera_lines;
+  bool debug_pub_camera_projections;
+  bool debug_pub_filtered_pointclouds;
+
   radians angular_resolution_;
 
   double resolution_;  // Map Resolution

--- a/igvc_navigation/src/mapper/ros_mapper.h
+++ b/igvc_navigation/src/mapper/ros_mapper.h
@@ -87,7 +87,7 @@ private:
    * @param[in] frame_id the frame to use
    * @param[in] stamp the stamp to use
    */
-  void publishAsPCL(const ros::Publisher& pub, const cv::Mat& mat, const std::string& frame_id, uint64_t stamp);
+  void publishMapDebugPC(const ros::Publisher& pub, const cv::Mat& mat, const std::string& frame_id, uint64_t stamp);
 
   cv_bridge::CvImage img_bridge_;
 
@@ -107,7 +107,7 @@ private:
   int length_x_{};  // length (m)
   int width_y_{};   // width (m)
 
-  bool debug_{};
+  bool debug_pub_map_pcl{};
 
   bool enable_left_cam_;
   bool enable_center_cam_;


### PR DESCRIPTION
This PR adds a parameters to give more fine grain control over which debug topics are published in the mapper. Additionally, "debug" has been added to the published topics to distinguish them from topics which are essential. Fixes #425.