### PR TITLE
Fixed parameter name for imu_top.launch

### DIFF
--- a/igvc_platform/launch/imu_top.launch
+++ b/igvc_platform/launch/imu_top.launch
@@ -7,7 +7,7 @@
     <node pkg="igvc_platform" name="imu_top" type="imu" output="screen" >
         <param name="SERIAL_PORT" type="string" value="/dev/imu_top" />
         <param name="frame_id" type="string" value="magnetometer"/>
-        <param name="imu_orientation_correction" value="1.945" />
+        <param name="orientation_rotation" value="1.945" />
         <remap from="imu" to="magnetometer" />
     </node>
 </launch>


### PR DESCRIPTION
This PR fixes the parameter name for `imu_top.launch` so that it actually is a correction.