### PR TITLE
Created launch file for extracting left, center and right camera images from bagfiles

### DIFF
--- a/igvc_utils/launch/extract_jpegs.launch
+++ b/igvc_utils/launch/extract_jpegs.launch
@@ -1,0 +1,44 @@
+<!-- Launch file for extracting left, center and right camera images.
+
+Example usage:
+ROS_HOME=`pwd` roslaunch igvc_utils extract_jpegs.launch bagfile:=1.bag output_dir:=1
+
+    -->
+<launch>
+    <arg name="bagfile" />
+    <arg name="output_dir" default="./" />
+    <arg name="left_raw" default="/usb_cam_left/raw" />
+    <arg name="left_compressed" default="/usb_cam_left/image_raw" />
+
+    <arg name="center_raw" value="/usb_cam_center/raw" />
+    <arg name="center_compressed" default="/usb_cam_center/image_raw" />
+
+    <arg name="right_raw" value="/usb_cam_right/raw" />
+    <arg name="right_compressed" value="/usb_cam_right/image_raw" />
+
+    <arg name="secs_per_frame" default="1" />
+
+    <node pkg="rosbag" type="play" name="rosbag" required="true" args="$(arg bagfile) -r 10"/>
+
+    <node name="extract_left" pkg="image_view" type="extract_images" respawn="false" required="true" output="screen" cwd="ROS_HOME">
+        <remap from="image" to="$(arg left_raw)"/>
+        <param name="filename_format" value="$(arg output_dir)/left_%04i.jpg" />
+        <param name="secs_per_frame" value="$(eval 0.1 * arg('secs_per_frame'))" />
+    </node>
+    <node name="decompress_left" pkg="image_transport" type="republish" args="compressed in:=$(arg left_compressed) out:=$(arg left_raw)" />
+
+    <node name="extract_center" pkg="image_view" type="extract_images" respawn="false" required="true" output="screen" cwd="ROS_HOME">
+        <remap from="image" to="$(arg center_raw)"/>
+        <param name="filename_format" value="$(arg output_dir)/center_%04i.jpg" />
+        <param name="secs_per_frame" value="$(eval 0.1 * arg('secs_per_frame'))" />
+    </node>
+    <node name="decompress_center" pkg="image_transport" type="republish" args="compressed in:=$(arg center_compressed) out:=$(arg center_raw)" />
+
+    <node name="extract_right" pkg="image_view" type="extract_images" respawn="false" required="true" output="screen" cwd="ROS_HOME">
+        <remap from="image" to="$(arg right_raw)"/>
+        <param name="filename_format" value="$(arg output_dir)/right_%04i.jpg" />
+        <param name="secs_per_frame" value="$(eval 0.1 * arg('secs_per_frame'))" />
+    </node>
+    <node name="decompress_right" pkg="image_transport" type="republish" args="compressed in:=$(arg right_compressed) out:=$(arg right_raw)" />
+
+</launch>


### PR DESCRIPTION
This PR creates a utility launch file for extracting the left, center and right camera images from a bagfile.

Usage:
```shell
ROS_HOME=`pwd` roslaunch igvc_utils extract_jpegs.launch bagfile:=1.bag output_dir:=1
```