### PR TITLE
Added documents folder for research and design docments to be placed

### DIFF
--- a/documents/README.md
+++ b/documents/README.md
@@ -1,0 +1,8 @@
+# IGVC Docs
+This folder contains research and design documents for the repo.
+
+## Research Docs
+Currently we have none.
+
+## Design Docs
+Currently we have none.

--- a/documents/design/README.md
+++ b/documents/design/README.md
@@ -1,0 +1,1 @@
+# Design Docs

--- a/documents/research/README.md
+++ b/documents/research/README.md
@@ -1,0 +1,1 @@
+# Research Docs

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,8 @@ The repo is comprised of multiple ROS packages and one sandbox folder for miscel
     *A collection of utility nodes and classes*
  * **sandbox**
     *Miscellaneous resources, including the models used by the neural network, udev rules, and waypoints files*
+ * **documents**
+    *Research and design documents.*
 
 ## Building Documentation
 Documentation for our code can be generated via the rosdoc_lite tool.


### PR DESCRIPTION
This PR creates a `documents` folder, as well as `research` and `design` subfolders for research and design documents to be placed as a part of changes to project management workflow for this year.