### PR TITLE
Fix trajectory planner crashing when trajectory is empty

### DIFF
--- a/igvc_navigation/src/trajectory_planner/trajectory_planner.cpp
+++ b/igvc_navigation/src/trajectory_planner/trajectory_planner.cpp
@@ -172,6 +172,11 @@ void TrajectoryPlanner::updateTrajectory()
       publishTrajectory(empty_traj);
     }
 
+    if (!trajectory || trajectory.value().get() == nullptr || trajectory.value()->trajectory.empty())
+    {
+      publishStop();
+    }
+
     if (trajectory && trajectory.value().get() != nullptr)
     {
       publishDebug(*trajectory);
@@ -179,6 +184,17 @@ void TrajectoryPlanner::updateTrajectory()
       publishTrajectory(*trajectory);
     }
   }
+}
+
+void TrajectoryPlanner::publishStop()
+{
+  igvc_msgs::trajectory trajectory;
+  igvc_msgs::trajectory_point trajectory_point;
+  trajectory_point.velocity = 0.0;
+  trajectory_point.curvature = 0.0;
+  trajectory.trajectory.emplace_back(trajectory_point);
+
+  trajectory_pub_.publish(trajectory);
 }
 
 std::optional<igvc_msgs::trajectoryPtr> TrajectoryPlanner::getSmoothPath()

--- a/igvc_navigation/src/trajectory_planner/trajectory_planner.cpp
+++ b/igvc_navigation/src/trajectory_planner/trajectory_planner.cpp
@@ -175,14 +175,12 @@ void TrajectoryPlanner::updateTrajectory()
     if (!trajectory || trajectory.value().get() == nullptr || trajectory.value()->trajectory.empty())
     {
       publishStop();
+      continue;
     }
 
-    if (trajectory && trajectory.value().get() != nullptr)
-    {
-      publishDebug(*trajectory);
-      motion_profiler_->profileTrajectory(*trajectory, state_);
-      publishTrajectory(*trajectory);
-    }
+    publishDebug(*trajectory);
+    motion_profiler_->profileTrajectory(*trajectory, state_);
+    publishTrajectory(*trajectory);
   }
 }
 

--- a/igvc_navigation/src/trajectory_planner/trajectory_planner.h
+++ b/igvc_navigation/src/trajectory_planner/trajectory_planner.h
@@ -22,6 +22,7 @@ private:
   void encoderCallback(const igvc_msgs::velocity_pairConstPtr& msg);
   void updateTrajectory();
 
+  void publishStop();
   void publishTrajectory(const igvc_msgs::trajectoryConstPtr& trajectory);
   void publishDebug(const igvc_msgs::trajectoryConstPtr& trajectory);
 


### PR DESCRIPTION
# Description

`trajectory_planner` crashes in gazebo if you let Jessii run till the end of the course, due to #493.

This PR does the following:
- Adds a check for empty trajectory generated in `trajectory_planner` and publishes a stopping trajectory to prevent the node from crashing.

Fixes #493.

# Testing steps (If relevant)
## Test that `trajectory_planner` no longer crashes
0. Switch to the `master` branch and build
1. Launch gazebo. `roslaunch igvc_gazebo qualification.launch`
2. Launch the navigation stack. `roslaunch igvc_navigation_simulation.launch`
3. Let Jessii navigate to the last waypoint
4. Verify that #493 is occuring, ie. `trajectory_planner` is crashing when 3 happens
5. Switch back to this (`bug/trajectory_planner_empty_path_crash` and rebuild
6. Perform 1 - 3 again

Expectation: `trajectory_planner` stays alive even at the last waypoint

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
