### PR TITLE
Feat/implement costmap2d interfaces

### DIFF
--- a/igvc_navigation/config/global_costmap_params.yaml
+++ b/igvc_navigation/config/global_costmap_params.yaml
@@ -2,8 +2,17 @@ global_costmap:
     global_frame: odom
     plugins:
         - {name: wrapper_layer,     type: "wrapper_layer::WrapperLayer"}
-    publish_frequency: 1.0
+        - {name: inflation_layer,   type: "costmap_2d::InflationLayer"}
+    publish_frequency: 5.0
     robot_radius: 1.0
     width: 200
     height: 200
+    origin_x: -100
+    origin_y: -100
+    track_unknown_space: true
+    unknown_cost_value: 30
+    static_map: false
+    rolling_window: false
     resolution: 0.2
+    inflation:
+        inflation_radius: 0.35

--- a/igvc_navigation/config/local_costmap_params.yaml
+++ b/igvc_navigation/config/local_costmap_params.yaml
@@ -1,4 +1,5 @@
 local_costmap:
+    plugins: []
     global_frame: odom
     update_frequency: 5.0
     rolling_window: true

--- a/igvc_navigation/launch/mapper_wrapper.launch
+++ b/igvc_navigation/launch/mapper_wrapper.launch
@@ -11,5 +11,6 @@
 
         <!-- Mapper config -->
         <rosparam file="$(find igvc_navigation)/config/octomap_sim.yaml" command="load" />
+        <param name="lethal_threshold" value="0.8" /> <!-- threshold for LETHAL_OBSTACLE (0.0 - 1.0) -->
     </node>
 </launch>

--- a/igvc_navigation/src/mapper/ros_mapper.h
+++ b/igvc_navigation/src/mapper/ros_mapper.h
@@ -20,7 +20,6 @@ class ROSMapper
 public:
   ROSMapper();
 
-private:
   /**
    * Callback for pointcloud. Inserted into the map as a lidar scan.
    * @param[in] pc Lidar scan

--- a/igvc_navigation/src/mapper/wrapper_layer.cpp
+++ b/igvc_navigation/src/mapper/wrapper_layer.cpp
@@ -36,12 +36,11 @@ void WrapperLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, in
     return;
   }
 
-  bool assumptions = master_grid.getSizeInMetersX() == mapper_.length_x_ &&
-                     master_grid.getSizeInMetersY() == mapper_.width_y_ &&
-                     master_grid.getResolution() == mapper_.resolution_ &&
-                     static_cast<int>(master_grid.getSizeInCellsX()) == map->rows &&
-                     static_cast<int>(master_grid.getSizeInCellsY()) == map->cols;
-  assert(assumptions);
+  ROS_ASSERT(master_grid.getSizeInMetersX() == mapper_.length_x_);
+  ROS_ASSERT(master_grid.getSizeInMetersY() == mapper_.width_y_);
+  ROS_ASSERT(master_grid.getResolution() == mapper_.resolution_);
+  ROS_ASSERT(static_cast<int>(master_grid.getSizeInCellsX()) == map->rows);
+  ROS_ASSERT(static_cast<int>(master_grid.getSizeInCellsY()) == map->cols);
 
   unsigned char* master = master_grid.getCharMap();
 
@@ -62,7 +61,7 @@ void WrapperLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, in
       }
       else
       {
-        master[idx] = costmap_2d::FREE_SPACE;
+        master[idx] = p[j];
       }
     }
   }

--- a/igvc_navigation/src/mapper/wrapper_layer.cpp
+++ b/igvc_navigation/src/mapper/wrapper_layer.cpp
@@ -42,8 +42,8 @@ void WrapperLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, in
 
   for (int i = 0; i < 255; i++)
   {
-    master[2*i] = static_cast<uchar>(i);
-    master[2*i+1] = static_cast<uchar>(i);
+    master[2 * i] = static_cast<uchar>(i);
+    master[2 * i + 1] = static_cast<uchar>(i);
   }
 
   unsigned int mx, my;

--- a/igvc_navigation/src/mapper/wrapper_layer.cpp
+++ b/igvc_navigation/src/mapper/wrapper_layer.cpp
@@ -16,10 +16,65 @@ void WrapperLayer::onInitialize()
 void WrapperLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,
                                 double* max_x, double* max_y)
 {
+  *min_x = -mapper_.length_x_ / 2.0;
+  *min_y = -mapper_.width_y_ / 2.0;
+  *max_x = mapper_.length_x_ / 2.0;
+  *max_y = mapper_.width_y_ / 2.0;
 }
 
 void WrapperLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j)
 {
+  std::optional<cv::Mat> map = mapper_.mapper_->getMap();
+  if (!map)
+  {
+    ROS_WARN_STREAM_THROTTLE(1, "Couldn't get a map");
+    return;
+  }
+
+  bool assumptions = master_grid.getSizeInMetersX() == mapper_.length_x_ &&
+                     master_grid.getSizeInMetersY() == mapper_.width_y_ &&
+                     master_grid.getResolution() == mapper_.resolution_ &&
+                     static_cast<int>(master_grid.getSizeInCellsX()) == map->rows &&
+                     static_cast<int>(master_grid.getSizeInCellsY()) == map->cols;
+  assert(assumptions);
+
+  unsigned char* master = master_grid.getCharMap();
+
+  for (int i = 0; i < 255; i++)
+  {
+    master[2*i] = static_cast<uchar>(i);
+    master[2*i+1] = static_cast<uchar>(i);
+  }
+
+  unsigned int mx, my;
+  master_grid.worldToMap(0.0, 0.0, mx, my);
+  unsigned int index = master_grid.getIndex(mx, my);
+  //  ROS_INFO("W(0.0, 0.0) -> M(%d, %d)", mx, my);
+  master[index - 1] = 255u;
+  master[index] = 255u;
+  master[index + 1] = 255u;
+
+  int nRows = mapper_.width_y_ / mapper_.resolution_;
+  int nCols = mapper_.length_x_ / mapper_.resolution_;
+
+  pcl::PointCloud<pcl::PointXYZ> pointcloud;
+
+  for (int i = 0; i < nRows; ++i)
+  {
+    uchar* p = map->ptr<uchar>(i);
+    for (int j = 0; j < nCols; ++j)
+    {
+      auto idx = master_grid.getIndex(i, j);
+      if (p[j] > 200u)
+      {
+        master[idx] = costmap_2d::LETHAL_OBSTACLE;
+      }
+      else
+      {
+        master[idx] = costmap_2d::FREE_SPACE;
+      }
+    }
+  }
 }
 
 }  // namespace wrapper_layer

--- a/igvc_navigation/src/mapper/wrapper_layer.h
+++ b/igvc_navigation/src/mapper/wrapper_layer.h
@@ -5,6 +5,7 @@
 #include <costmap_2d/layer.h>
 #include <costmap_2d/layered_costmap.h>
 #include <ros/ros.h>
+#include <mutex>
 
 #include "ros_mapper.h"
 

--- a/igvc_navigation/src/mapper/wrapper_layer.h
+++ b/igvc_navigation/src/mapper/wrapper_layer.h
@@ -23,6 +23,7 @@ public:
 
 private:
   ROSMapper mapper_;
+  uchar occupied_threshold_;
 };
 }  // namespace wrapper_layer
 


### PR DESCRIPTION
# Description

Per the refactor plan, the next step is to actually implement the interfaces for costmap2d

This PR does the following:
- Implement the interfaces for the costmap2d layer for our mapper

Fixes #486

# Testing steps (If relevant)
## Test that the old functionality still works in simulation and the costmap2d interfaces are implemented
1. Run simulation by launching `igvc_gazebo qualification.launch`
2. Run the navigation stack by launching `igvc_navigation navigation_simulation.launch`

Expectation: There should be a topic for the global costmap that shows the map in rviz.

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
