### PR TITLE
Reduce CPU usage by sim_color_detector

### DIFF
--- a/igvc_gazebo/nodes/sim_color_detector/main.cpp
+++ b/igvc_gazebo/nodes/sim_color_detector/main.cpp
@@ -88,7 +88,7 @@ void handleImage(const sensor_msgs::ImageConstPtr& msg, std::string camera_name)
   try
   {
     cv_ptr = cv_bridge::toCvCopy(msg, "bgr8");
-    frame = cv_bridge::toCvCopy(msg, "bgr8")->image;
+    frame = cv_ptr->image;
   }
   catch (cv_bridge::Exception& e)
   {

--- a/igvc_gazebo/nodes/sim_color_detector/main.cpp
+++ b/igvc_gazebo/nodes/sim_color_detector/main.cpp
@@ -177,10 +177,5 @@ int main(int argc, char** argv)
     g_pubs.insert(std::make_pair(camera_name, camera_pubs));
   }
 
-  while (ros::ok())
-  {
-    ros::spinOnce();
-  }
-
-  return 0;
+  ros::spin();
 }


### PR DESCRIPTION
# Description

`sim_color_detector` has high CPU usage due to repeatedly running OpenCV scripts. The spin loop was not the main cause of it, but it's still possible to optimize.

This PR does the following:
- Replace `spinOnce()` in loop with `spin()`.
- Make a minor optimization to reduce number of CPU-heavy tasks.

Fixes #489.

# Testing steps (If relevant)
## Check that CPU usage is down and simulator works
1. Run simulation by launching igvc_gazebo qualification.launch
2. Run `ps -e -o  %cpu,cmd | grep -i igvc_gazebo/sim_color` to check CPU usage by process

Expectation: CPU usage by `sim_color_detector` should be down to around 100% and simulator still works.

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
