### PR TITLE
Bug/trajectory planner runs as fast as possible

### DIFF
--- a/igvc_navigation/src/trajectory_planner/trajectory_planner.cpp
+++ b/igvc_navigation/src/trajectory_planner/trajectory_planner.cpp
@@ -177,18 +177,15 @@ void TrajectoryPlanner::updateTrajectory()
       publishStop();
     }
 
-<<<<<<< HEAD
     if (trajectory && trajectory.value().get() != nullptr)
     {
       publishDebug(*trajectory);
       motion_profiler_->profileTrajectory(*trajectory, state_);
       publishTrajectory(*trajectory);
     }
-=======
     publishDebug(*trajectory);
     motion_profiler_->profileTrajectory(*trajectory, state_);
     publishTrajectory(*trajectory);
->>>>>>> Rebased with new master branch
     rate.sleep();
   }
 }

--- a/igvc_navigation/src/trajectory_planner/trajectory_planner.cpp
+++ b/igvc_navigation/src/trajectory_planner/trajectory_planner.cpp
@@ -175,12 +175,15 @@ void TrajectoryPlanner::updateTrajectory()
     if (!trajectory || trajectory.value().get() == nullptr || trajectory.value()->trajectory.empty())
     {
       publishStop();
-      continue;
     }
 
-    publishDebug(*trajectory);
-    motion_profiler_->profileTrajectory(*trajectory, state_);
-    publishTrajectory(*trajectory);
+    if (trajectory && trajectory.value().get() != nullptr)
+    {
+      publishDebug(*trajectory);
+      motion_profiler_->profileTrajectory(*trajectory, state_);
+      publishTrajectory(*trajectory);
+    }
+    rate.sleep();
   }
 }
 

--- a/igvc_navigation/src/trajectory_planner/trajectory_planner.cpp
+++ b/igvc_navigation/src/trajectory_planner/trajectory_planner.cpp
@@ -177,12 +177,18 @@ void TrajectoryPlanner::updateTrajectory()
       publishStop();
     }
 
+<<<<<<< HEAD
     if (trajectory && trajectory.value().get() != nullptr)
     {
       publishDebug(*trajectory);
       motion_profiler_->profileTrajectory(*trajectory, state_);
       publishTrajectory(*trajectory);
     }
+=======
+    publishDebug(*trajectory);
+    motion_profiler_->profileTrajectory(*trajectory, state_);
+    publishTrajectory(*trajectory);
+>>>>>>> Rebased with new master branch
     rate.sleep();
   }
 }

--- a/igvc_navigation/src/trajectory_planner/trajectory_planner.cpp
+++ b/igvc_navigation/src/trajectory_planner/trajectory_planner.cpp
@@ -175,14 +175,9 @@ void TrajectoryPlanner::updateTrajectory()
     if (!trajectory || trajectory.value().get() == nullptr || trajectory.value()->trajectory.empty())
     {
       publishStop();
+      continue;
     }
 
-    if (trajectory && trajectory.value().get() != nullptr)
-    {
-      publishDebug(*trajectory);
-      motion_profiler_->profileTrajectory(*trajectory, state_);
-      publishTrajectory(*trajectory);
-    }
     publishDebug(*trajectory);
     motion_profiler_->profileTrajectory(*trajectory, state_);
     publishTrajectory(*trajectory);


### PR DESCRIPTION
# Description
Currently, the trajectory_planner runs as fast as possible, using more CPU than required. 

This PR does the following:
- Adds a rate.sleep() that slows down the node to the rate specified by loop_hz_

Fixes #497

# Testing steps (If relevant)
1. checkout master
2. build and `roslaunch igvc_gazebo qualification.launch`
3. `roslaunch igvc_navigation navigation_simulation.launch`
4. run `rostopic hz trajectory` to see that's it's running faster than 20hz
5. checkout bug/trajectory_planner_runs_as_fast_as_possible and repeat steps 3 and 4.
6. run `rostopic hz trajectory` to see that's it's running at 20hz.

Expectation: 
The rostopic trajectory should run at 20hz

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
