### PR TITLE
Fixed bug with occupied threshold, and removed occupancy to conform with costmap2d convention

### DIFF
--- a/igvc_navigation/src/mapper/wrapper_layer.cpp
+++ b/igvc_navigation/src/mapper/wrapper_layer.cpp
@@ -11,7 +11,7 @@ WrapperLayer::WrapperLayer() : mapper_{}
   ros::NodeHandle private_nh{ "~" };
   double threshold_double;
   assertions::getParam(private_nh, "lethal_threshold", threshold_double);
-  occupied_threshold_ = static_cast<uchar>(std::round(255.0 / threshold_double));
+  occupied_threshold_ = static_cast<uchar>(std::round(255.0 * threshold_double));
 }
 
 void WrapperLayer::onInitialize()
@@ -61,7 +61,7 @@ void WrapperLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, in
       }
       else
       {
-        master[idx] = p[j];
+        master[idx] = costmap_2d::FREE_SPACE;
       }
     }
   }


### PR DESCRIPTION
# Description

This PR does the following:
- Fixes #501
- Changes the probabilistic occupancy part in the wrapper conversion to just simply discretize as `costmap2d::FREE_SPACE` as according to their documentation:
> While each cell in the costmap can have one of 255 different cost values (see the inflation section), the underlying structure that it uses is capable of representing only three

# Testing steps (If relevant)
## Check that the entire map is not occupied
1. Launch gazebo: `roslaunch igvc_gazebo qualification.launch`
2. Launch navigation stack: `roslaunch igvc_navigation navigation_simulation.launch`
3. Make sure you have the `Map` display turned on with display mode set to `Costmap`.

Expectation: Only obstacles are occupied (purple). Everything else should be transparent.

# Self Checklist
- [ ] I have formatted my code using `make format`
- [ ] I have tested that the new behaviour works 
