### PR TITLE
Unified all camera frames to have a "cam" prefix, resized sim_detector output to be 400x400, adds lines to mapper in simulation

### DIFF
--- a/igvc_description/urdf/jessii.urdf.xacro
+++ b/igvc_description/urdf/jessii.urdf.xacro
@@ -272,11 +272,11 @@
   </joint>
 
   <!-- the optical joint is in the correct frame for transforms -->
-  <link name="center_cam_optical"/>
+  <link name="cam/center_optical"/>
 
-  <joint name="center_cam_optical_joint" type="fixed">
+  <joint name="cam/center_optical_joint" type="fixed">
       <parent link="center_cam"/>
-      <child link="center_cam_optical"/>
+      <child link="cam/center_optical"/>
       <origin xyz="0 0 0" rpy="-1.5708 0 -1.5708"/>
   </joint>
 
@@ -309,10 +309,10 @@
           <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
               <alwaysOn>true</alwaysOn>
               <updateRate>30</updateRate>
-              <cameraName>center_cam</cameraName>
+              <cameraName>cam/center</cameraName>
               <imageTopicName>image_raw</imageTopicName>
               <cameraInfoTopicName>camera_info</cameraInfoTopicName>
-              <frameName>center_cam_optical</frameName>
+              <frameName>cam/center_optical</frameName>
               <hackBaseline>0.0</hackBaseline>
               <distortionK1>0.0</distortionK1>
               <distortionK2>0.0</distortionK2>
@@ -338,11 +338,11 @@
   </joint>
 
   <!-- the optical joint is in the correct frame for transforms -->
-  <link name="right_cam_optical"/>
+  <link name="cam/right_optical"/>
 
-  <joint name="right_cam_optical_joint" type="fixed">
+  <joint name="cam/right_optical_joint" type="fixed">
       <parent link="right_cam"/>
-      <child link="right_cam_optical"/>
+      <child link="cam/right_optical"/>
       <origin xyz="0 0 0" rpy="-1.5708 0 -1.5708"/>
   </joint>
 
@@ -375,10 +375,10 @@
           <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
               <alwaysOn>true</alwaysOn>
               <updateRate>30</updateRate>
-              <cameraName>right_cam</cameraName>
+              <cameraName>cam/right</cameraName>
               <imageTopicName>image_raw</imageTopicName>
               <cameraInfoTopicName>camera_info</cameraInfoTopicName>
-              <frameName>right_cam_optical</frameName>
+              <frameName>cam/right_optical</frameName>
               <hackBaseline>0.0</hackBaseline>
               <distortionK1>0.0</distortionK1>
               <distortionK2>0.0</distortionK2>
@@ -404,11 +404,11 @@
   </joint>
 
   <!-- the optical joint is in the correct frame for transforms -->
-  <link name="left_cam_optical"/>
+  <link name="cam/left_optical"/>
 
-  <joint name="left_cam_optical_joint" type="fixed">
+  <joint name="cam/left_optical_joint" type="fixed">
       <parent link="left_cam"/>
-      <child link="left_cam_optical"/>
+      <child link="cam/left_optical"/>
       <origin xyz="0 0 0" rpy="-1.5708 0 -1.5708"/>
   </joint>
 
@@ -441,10 +441,10 @@
           <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
               <alwaysOn>true</alwaysOn>
               <updateRate>30</updateRate>
-              <cameraName>left_cam</cameraName>
+              <cameraName>cam/left</cameraName>
               <imageTopicName>image_raw</imageTopicName>
               <cameraInfoTopicName>camera_info</cameraInfoTopicName>
-              <frameName>left_cam_optical</frameName>
+              <frameName>cam/left_optical</frameName>
               <hackBaseline>0.0</hackBaseline>
               <distortionK1>0.0</distortionK1>
               <distortionK2>0.0</distortionK2>

--- a/igvc_gazebo/launch/sim_detector.launch
+++ b/igvc_gazebo/launch/sim_detector.launch
@@ -2,12 +2,17 @@
 
 <launch>
 
-  <node name="sim_color_detector" pkg="igvc_gazebo" type="sim_color_detector">
+  <node name="sim_color_detector" pkg="igvc_gazebo" type="sim_color_detector" output="screen">
       <!-- names of cameras to subscribe to -->
-      <rosparam param="camera_names">["/center_cam", "/left_cam", "/right_cam"]</rosparam>
+      <rosparam param="camera_names">["/cam/center", "/cam/left", "/cam/right"]</rosparam>
+      <rosparam param="semantic_topic_prefix">["/cam/center", "/cam/left", "/cam/right"]</rosparam>
+      <rosparam param="semantic_topic_suffix">["", "", ""]</rosparam>
+
+      <param name="output_image/width" value="400" />
+      <param name="output_image/height" value="400" />
 
       <!-- names of output segmentation topics. Published in the namespace of the corresponding camera -->
-      <param name="line_topic" value="/detected_lines" />
+      <param name="line_topic" value="/semantic_segmentation" />
       <param name="barrel_topic" value="/detected_barrels" />
   </node>
 

--- a/igvc_navigation/config/octomap.yaml
+++ b/igvc_navigation/config/octomap.yaml
@@ -77,23 +77,23 @@ segmented_free_space:
 topics:
     lidar: "/velodyne_points"
     line_segmentation:
-        left: "/semantic_segmentation/usb_cam_left"
-        center: "/semantic_segmentation/usb_cam_center"
-        right: "/semantic_segmentation/usb_cam_right"
+        left: "/cam/left/semantic_segmentation"
+        center: "/cam/center/semantic_segmentation"
+        right: "/cam/right/semantic_segmentation"
     projected_line_pc:
-        left: "/semantic_segmentation_cloud/usm_cam_left"
-        center: "/semantic_segmentation_cloud/usb_cam_center"
-        right: "/semantic_segmentation_cloud/usb_cam_right"
+        left: "/cam/left/semantic_segmentation_cloud"
+        center: "/cam/center/semantic_segmentation_cloud"
+        right: "/cam/right/semantic_segmentation_cloud"
     camera_info:
-        left: "/usb_cam_left/camera_info"
-        center: "/usb_cam_center/camera_info"
-        right: "/usb_cam_right/camera_info"
-    camera_center: "/usb_cam_center/image_raw/compressed"
+        left: "/cam/left/camera_info"
+        center: "/cam/center/camera_info"
+        right: "/cam/right/camera_info"
+    camera_center: "/cam/center/image_raw/compressed"
 frames:
     camera:
-        left: "/left_cam_optical"
-        center: "/center_cam_optical"
-        right: "/right_cam_optical"
+        left: "/cam/left_optical"
+        center: "/cam/center_optical"
+        right: "/cam/right_optical"
 node:
     debug:
         publish:

--- a/igvc_navigation/config/octomap_sim.yaml
+++ b/igvc_navigation/config/octomap_sim.yaml
@@ -77,23 +77,23 @@ segmented_free_space:
 topics:
     lidar: "/velodyne_points"
     line_segmentation:
-        left: "/semantic_segmentation/usb_cam_left"
-        center: "/semantic_segmentation/usb_cam_center"
-        right: "/semantic_segmentation/usb_cam_right"
+        left: "/cam/left/semantic_segmentation"
+        center: "/cam/center/semantic_segmentation"
+        right: "/cam/right/semantic_segmentation"
     projected_line_pc:
-        left: "/semantic_segmentation_cloud/usm_cam_left"
-        center: "/semantic_segmentation_cloud/usb_cam_center"
-        right: "/semantic_segmentation_cloud/usb_cam_right"
+        left: "/cam/left/semantic_segmentation_cloud"
+        center: "/cam/center/semantic_segmentation_cloud"
+        right: "/cam/right/semantic_segmentation_cloud"
     camera_info:
-        left: "/usb_cam_left/camera_info"
-        center: "/usb_cam_center/camera_info"
-        right: "/usb_cam_right/camera_info"
-    camera_center: "/usb_cam_center/image_raw/compressed"
+        left: "/cam/left/camera_info"
+        center: "/cam/center/camera_info"
+        right: "/cam/right/camera_info"
+    camera_center: "/cam/center/image_raw/compressed"
 frames:
     camera:
-        left: "/left_cam_optical"
-        center: "/center_cam_optical"
-        right: "/right_cam_optical"
+        left: "/cam/left_optical"
+        center: "/cam/center_optical"
+        right: "/cam/right_optical"
 node:
     debug:
         publish:
@@ -103,13 +103,13 @@ node:
                 projections: true
             filtered_pointclouds: true
 
-    use_lines: false
+    use_lines: true
     camera:
         use_passed_in_pointcloud: false
         left:
             enable: false
         center:
-            enable: false
+            enable: true
         right:
             enable: false
     transform_max_wait_time: 1

--- a/igvc_perception/launch/projection.launch
+++ b/igvc_perception/launch/projection.launch
@@ -4,8 +4,8 @@
   <node name="projection" pkg="igvc_perception" type="projection" output="screen">
     <param name="resize_width" type="int" value="640" />
     <param name="resize_height" type="int" value="480" />
-    <param name="line_topic" type="string" value="/center_cam/detected_lines" />
-    <param name="pointcloud_topic" type="string" value="/line_pointcloud" />
+    <param name="line_topic" type="string" value="/cam/center/semantic_segmentation" />
+    <param name="pointcloud_topic" type="string" value="/cam/center/semantic_segmentation_cloud" />
     <param name="lidar_topic" type="string" value="/velodyne_points" />
   </node>
 </launch>

--- a/igvc_perception/src/projection/main.cpp
+++ b/igvc_perception/src/projection/main.cpp
@@ -229,17 +229,17 @@ void addLinesToPointcloud(pcl::PointCloud<pcl::PointXYZ> &line_cloud,
 void getTransforms()
 {
   tf::TransformListener tf_listener;
-  if (tf_listener.waitForTransform("/center_cam_optical", "/lidar", ros::Time(0), ros::Duration(3.0)))
+  if (tf_listener.waitForTransform("/cam/center_optical", "/lidar", ros::Time(0), ros::Duration(3.0)))
   {
-    tf_listener.lookupTransform("/center_cam_optical", "/lidar", ros::Time(0), g_transform_lidar_to_cam);
+    tf_listener.lookupTransform("/cam/center_optical", "/lidar", ros::Time(0), g_transform_lidar_to_cam);
   }
   else
   {
     ROS_ERROR_STREAM("\n\nfailed to find lidar to camera transform\n\n");
   }
-  if (tf_listener.waitForTransform("/base_footprint", "/center_cam_optical", ros::Time(0), ros::Duration(3.0)))
+  if (tf_listener.waitForTransform("/base_footprint", "/cam/center_optical", ros::Time(0), ros::Duration(3.0)))
   {
-    tf_listener.lookupTransform("/base_footprint", "/center_cam_optical", ros::Time(0), g_transform_cam_to_base);
+    tf_listener.lookupTransform("/base_footprint", "/cam/center_optical", ros::Time(0), g_transform_cam_to_base);
   }
   else
   {
@@ -329,7 +329,7 @@ int main(int argc, char **argv)
   assertions::getParam(pNh, "pointcloud_topic", g_pointcloud_topic);
   assertions::getParam(pNh, "lidar_topic", g_lidar_topic);
 
-  g_cam_info = ros::topic::waitForMessage<sensor_msgs::CameraInfo>("center_cam/camera_info", ros::Duration(5));
+  g_cam_info = ros::topic::waitForMessage<sensor_msgs::CameraInfo>("cam/center/camera_info", ros::Duration(5));
   if (g_cam_info.get() != nullptr)
   {
     resizeCameraModel();


### PR DESCRIPTION
# Description

* Our camera topic names are not unified currently. The neural network uses
`/semantic_segmentation/usb_cam_left`, while the `sim_detector` node uses
`/center_cam/detected_lines`.
* The `sim_detector` node outputs 1920x1080 images for the semantic segmentation,
but our nn outputs 400x400
* Also, lines are currently not enabled for the mapper in gazebo.

This PR does the following:
- Unifies all camera topic names. All camera related things now live under the `cam` namespace, ie. `cam/center/raw_image`, or `cam/center/semantic_segmentation`
- Fixed the `sim_detector` to output 400x400 images to fit with the neural network
- Enabled lines for mapping in simulation

Fixes #450 and #498.

# Testing steps (If relevant)
## Lines are mapped and work in gazebo
1. Launch gazebo: roslaunch igvc_gazebo qualification.launch
2. Launch navigation stack: roslaunch igvc_navigation navigation_simulation.launch
3. Make sure you have the Map display turned on with display mode set to Costmap.

Expectation: Both lines and barrels show up in the costmap. Note, due to #492 the map is fucked up at the beginning.

## `sim_detector` outputs 400x400 images
1. Launch gazebo: roslaunch igvc_gazebo qualification.launch
2. Run `rostopic echo /cam/center/semantic_segmentation --noarr`

Expectation: Height and Width are both 400

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
