### PR TITLE
`lidar_layer` part of the mapper refactor

### DIFF
--- a/igvc_navigation/CMakeLists.txt
+++ b/igvc_navigation/CMakeLists.txt
@@ -25,6 +25,15 @@ find_package(catkin REQUIRED COMPONENTS
              costmap_2d
              dynamic_reconfigure
              igvc_utils
+             grid_map_core
+             grid_map_ros
+             grid_map_cv
+             grid_map_filters
+             grid_map_loader
+             grid_map_msgs
+             grid_map_octomap
+             grid_map_rviz_plugin
+             grid_map_visualization
     )
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
@@ -190,7 +199,8 @@ add_library(
     GraphSearch STATIC
     GraphSearch/src/Node.cpp
     GraphSearch/src/Graph.cpp
-    GraphSearch/src/PriorityQueue.cpp)
+    GraphSearch/src/PriorityQueue.cpp
+)
 add_dependencies(GraphSearch ${catkin_EXPORTED_TARGETS})
 # link OpenCV and cv_bridge to GraphSearch library
 target_link_libraries(GraphSearch ${OpenCV_LIBRARIES} ${catkin_LIBRARIES})

--- a/igvc_navigation/config/empty_global_costmap_params.yaml
+++ b/igvc_navigation/config/empty_global_costmap_params.yaml
@@ -1,0 +1,5 @@
+global_costmap:
+    plugins: []
+    global_frame: odom
+    update_frequency: 5.0
+    rolling_window: true

--- a/igvc_navigation/config/gridmap_viz.yaml
+++ b/igvc_navigation/config/gridmap_viz.yaml
@@ -1,0 +1,8 @@
+grid_map_topic: /mapper/debug/gridmap
+grid_map_visualizations:
+    - name: occupancy_grid
+      type: occupancy_grid
+      params:
+          layer: "probability"
+          data_min: 0.0
+          data_max: 1.0

--- a/igvc_navigation/config/refactored_local_costmap_params.yaml
+++ b/igvc_navigation/config/refactored_local_costmap_params.yaml
@@ -22,13 +22,15 @@ lidar_layer:
         length_x: 200
         length_y: 200
         occupied_threshold: 0.5
+        max_occupancy: 0.99
+        min_occupancy: 0.01
         debug:
             map_topic: "/mapper/debug/gridmap"
     lidar:
         occupied_topic: "/lidar/occupied"
         free_topic: "/lidar/free"
         sensor_model:
-            scan_hit: 0.9
+            scan_hit: 0.7
             scan_miss: 0.8
             free_miss: 0.7
-            hit_exponential_coeff: 0.0
+            hit_exponential_coeff: 0.05

--- a/igvc_navigation/config/refactored_local_costmap_params.yaml
+++ b/igvc_navigation/config/refactored_local_costmap_params.yaml
@@ -1,0 +1,34 @@
+local_costmap:
+    global_frame: odom
+    plugins:
+        - {name: lidar_layer,     type: "lidar_layer::LidarLayer"}
+        - {name: inflation_layer,   type: "costmap_2d::InflationLayer"}
+    publish_frequency: 5.0
+    robot_radius: 1.0
+    width: 200
+    height: 200
+    origin_x: -100
+    origin_y: -100
+    track_unknown_space: true
+    static_map: false
+    rolling_window: false
+    resolution: 0.2
+    inflation:
+        inflation_radius: 0.35
+lidar_layer:
+    map:
+        frame_id: "odom"
+        resolution: 0.2
+        length_x: 200
+        length_y: 200
+        occupied_threshold: 0.5
+        debug:
+            map_topic: "/mapper/debug/gridmap"
+    lidar:
+        occupied_topic: "/lidar/occupied"
+        free_topic: "/lidar/free"
+        sensor_model:
+            scan_hit: 0.9
+            scan_miss: 0.8
+            free_miss: 0.7
+            hit_exponential_coeff: 0.0

--- a/igvc_navigation/include/mapper/probability_utils.h
+++ b/igvc_navigation/include/mapper/probability_utils.h
@@ -1,0 +1,19 @@
+#ifndef SRC_PROBABILITY_UTILS_H
+#define SRC_PROBABILITY_UTILS_H
+
+namespace probability_utils
+{
+template <typename T>
+T toLogOdds(T probability)
+{
+  return std::log(probability / (1 - probability));
+}
+
+template <typename T>
+T fromLogOdds(T logodds)
+{
+  return 1.0 - (1.0 / (1 + std::exp(logodds)));
+}
+}  // namespace probability_utils
+
+#endif  // SRC_PROBABILITY_UTILS_H

--- a/igvc_navigation/launch/gridmap_viz.launch
+++ b/igvc_navigation/launch/gridmap_viz.launch
@@ -1,0 +1,5 @@
+<launch>
+    <node pkg="grid_map_visualization" type="grid_map_visualization" name="grid_map_visualization" output="screen">
+        <rosparam command="load" file="$(find igvc_navigation)/config/gridmap_viz.yaml" />
+    </node>
+</launch>

--- a/igvc_navigation/launch/refactored_mapper.launch
+++ b/igvc_navigation/launch/refactored_mapper.launch
@@ -1,0 +1,12 @@
+<launch>
+    <!-- Move Base Flex -->
+    <node pkg="mbf_costmap_nav" type="mbf_costmap_nav" respawn="false" name="move_base_flex" output="screen">libsimple_layer
+        <param name="tf_timeout" value="1.5"/>
+        <param name="planner_max_retries" value="3"/>
+        <rosparam file="$(find igvc_navigation)/config/planners.yaml" command="load" />
+        <rosparam file="$(find igvc_navigation)/config/controllers.yaml" command="load" />
+        <rosparam file="$(find igvc_navigation)/config/recovery_behaviors.yaml" command="load" />
+        <rosparam file="$(find igvc_navigation)/config/empty_global_costmap_params.yaml" command="load" />
+        <rosparam file="$(find igvc_navigation)/config/refactored_local_costmap_params.yaml" command="load" />
+    </node>
+</launch>

--- a/igvc_navigation/launch/refactored_mapper.launch
+++ b/igvc_navigation/launch/refactored_mapper.launch
@@ -9,4 +9,6 @@
         <rosparam file="$(find igvc_navigation)/config/empty_global_costmap_params.yaml" command="load" />
         <rosparam file="$(find igvc_navigation)/config/refactored_local_costmap_params.yaml" command="load" />
     </node>
+
+    <include file="$(find igvc_perception)/launch/pointcloud_filter.launch" />
 </launch>

--- a/igvc_navigation/package.xml
+++ b/igvc_navigation/package.xml
@@ -55,6 +55,7 @@
   <build_depend>igvc_utils</build_depend>
   <build_depend>octomap</build_depend>
   <build_depend>octomap_ros</build_depend>
+  <build_depend>grid_map</build_depend>
 
   <!-- Run dependencies -->
   <exec_depend>cv_bridge</exec_depend>

--- a/igvc_navigation/src/mapper/CMakeLists.txt
+++ b/igvc_navigation/src/mapper/CMakeLists.txt
@@ -21,6 +21,11 @@ add_library(wrapper_layer wrapper_layer.h wrapper_layer.cpp)
 add_dependencies(wrapper_layer ${catkin_EXPORTED_TARGETS})
 target_link_libraries(wrapper_layer ${catkin_LIBRARIES} mapper_lib)
 
+# Final part of refactor:
+add_library(lidar_layer lidar_layer.cpp lidar_layer.h)
+add_dependencies(lidar_layer ${catkin_EXPORTED_TARGETS})
+target_link_libraries(lidar_layer ${catkin_LIBRARIES})
+
 find_package(OpenMP)
 if (OpenMP_FOUND)
     target_link_libraries(mapper ${OpenMP_CXX_LIBRARIES})

--- a/igvc_navigation/src/mapper/CMakeLists.txt
+++ b/igvc_navigation/src/mapper/CMakeLists.txt
@@ -22,7 +22,11 @@ add_dependencies(wrapper_layer ${catkin_EXPORTED_TARGETS})
 target_link_libraries(wrapper_layer ${catkin_LIBRARIES} mapper_lib)
 
 # Final part of refactor:
-add_library(lidar_layer lidar_layer.cpp lidar_layer.h)
+add_library(lidar_layer
+    lidar_layer.cpp lidar_layer.h
+    lidar_layer_config.cpp lidar_layer_config.h
+    map_config.cpp map_config.h
+    lidar_config.cpp lidar_config.h eigen_hash.h)
 add_dependencies(lidar_layer ${catkin_EXPORTED_TARGETS})
 target_link_libraries(lidar_layer ${catkin_LIBRARIES})
 
@@ -32,7 +36,7 @@ if (OpenMP_FOUND)
 endif ()
 
 install(
-    TARGETS mapper
+    TARGETS mapper wrapper_layer lidar_layer
     ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
     LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
     RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/igvc_navigation/src/mapper/costmap_plugins.xml
+++ b/igvc_navigation/src/mapper/costmap_plugins.xml
@@ -1,6 +1,15 @@
-<library path="lib/libwrapper_layer">
-  <class type="wrapper_layer::WrapperLayer" base_class_type="costmap_2d::Layer">
-    <description>Wrapper layer that just wraps the current mapper. See
-      https://github.com/RoboJackets/igvc-software/issues/485</description>
-  </class>
-</library>
+<class_libraries>
+  <library path="lib/libwrapper_layer">
+    <class type="wrapper_layer::WrapperLayer" base_class_type="costmap_2d::Layer">
+      <description>Wrapper layer that just wraps the current mapper. See
+        https://github.com/RoboJackets/igvc-software/issues/485</description>
+    </class>
+  </library>
+  <library path="lib/liblidar_layer">
+    <class type="lidar_layer::LidarLayer" base_class_type="costmap_2d::Layer">
+      <description>
+        Lidar layer that performs occupancy grid mapping, using gridmap as the backing data structure.
+      </description>
+    </class>
+  </library>
+</class_libraries>

--- a/igvc_navigation/src/mapper/eigen_hash.h
+++ b/igvc_navigation/src/mapper/eigen_hash.h
@@ -1,0 +1,60 @@
+#ifndef SRC_EIGEN_HASH_H
+#define SRC_EIGEN_HASH_H
+
+#include <functional>
+
+#include <Eigen/Core>
+
+namespace std
+{
+template <typename Scalar, int Rows, int Cols>
+struct hash<Eigen::Matrix<Scalar, Rows, Cols>>
+{
+  // https://wjngkoh.wordpress.com/2015/03/04/c-hash-function-for-eigen-matrix-and-vector/
+  size_t operator()(const Eigen::Matrix<Scalar, Rows, Cols>& matrix) const
+  {
+    size_t seed = 0;
+    for (size_t i = 0; i < matrix.size(); ++i)
+    {
+      Scalar elem = *(matrix.data() + i);
+      seed ^= std::hash<Scalar>()(elem) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    }
+    return seed;
+  }
+};
+
+template <typename Scalar, int Rows, int Cols>
+struct hash<Eigen::Array<Scalar, Rows, Cols>>
+{
+  // https://wjngkoh.wordpress.com/2015/03/04/c-hash-function-for-eigen-matrix-and-vector/
+  size_t operator()(const Eigen::Array<Scalar, Rows, Cols>& matrix) const
+  {
+    size_t seed = 0;
+    for (Eigen::Index i = 0; i < matrix.size(); ++i)
+    {
+      Scalar elem = *(matrix.data() + i);
+      seed ^= std::hash<Scalar>()(elem) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    }
+    return seed;
+  }
+};
+
+template <typename Scalar, int Rows, int Cols>
+struct equal_to<Eigen::Array<Scalar, Rows, Cols>>
+{
+  bool operator()(const Eigen::Array<Scalar, Rows, Cols>& lhs, const Eigen::Array<Scalar, Rows, Cols>& rhs) const
+  {
+    for (Eigen::Index i = 0; i < lhs.size(); ++i)
+    {
+      if (*(lhs.data() + i) != *(rhs.data() + i))
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
+}  // namespace std
+
+#endif  // SRC_EIGEN_HASH_H

--- a/igvc_navigation/src/mapper/lidar_config.cpp
+++ b/igvc_navigation/src/mapper/lidar_config.cpp
@@ -1,0 +1,27 @@
+#include "lidar_config.h"
+#include <mapper/probability_utils.h>
+#include <parameter_assertions/assertions.h>
+
+namespace lidar_layer
+{
+LidarConfig::LidarConfig(const ros::NodeHandle& parent_nh)
+{
+  ros::NodeHandle nh{ parent_nh, "lidar" };
+
+  assertions::getParam(nh, "occupied_topic", occupied_topic);
+  assertions::getParam(nh, "free_topic", free_topic);
+  assertions::getParam(nh, "free_topic", free_topic);
+
+  assertions::getParam(nh, "sensor_model/scan_hit", scan_hit);
+  // no log odds since conversion is done during markScanHit since its a function of distance
+
+  assertions::getParam(nh, "sensor_model/scan_miss", scan_miss);
+  scan_miss = probability_utils::toLogOdds(1.0 - scan_miss);  // It's a miss, so 1 - hit
+
+  assertions::getParam(nh, "sensor_model/free_miss", free_miss);
+  free_miss = probability_utils::toLogOdds(1.0 - free_miss);  // It's a miss, so 1 - hit
+
+  assertions::getParam(nh, "sensor_model/hit_exponential_coeff", hit_exponential_coeff);
+}
+
+}  // namespace lidar_layer

--- a/igvc_navigation/src/mapper/lidar_config.cpp
+++ b/igvc_navigation/src/mapper/lidar_config.cpp
@@ -13,7 +13,7 @@ LidarConfig::LidarConfig(const ros::NodeHandle& parent_nh)
   assertions::getParam(nh, "free_topic", free_topic);
 
   assertions::getParam(nh, "sensor_model/scan_hit", scan_hit);
-  // no log odds since conversion is done during markScanHit since its a function of distance
+  scan_hit = probability_utils::toLogOdds(scan_hit);
 
   assertions::getParam(nh, "sensor_model/scan_miss", scan_miss);
   scan_miss = probability_utils::toLogOdds(1.0 - scan_miss);  // It's a miss, so 1 - hit

--- a/igvc_navigation/src/mapper/lidar_config.h
+++ b/igvc_navigation/src/mapper/lidar_config.h
@@ -1,0 +1,23 @@
+#ifndef SRC_LIDAR_CONFIG_H
+#define SRC_LIDAR_CONFIG_H
+
+#include <ros/ros.h>
+
+namespace lidar_layer
+{
+class LidarConfig
+{
+public:
+  LidarConfig(const ros::NodeHandle& parent_nh);
+
+  std::string occupied_topic;
+  std::string free_topic;
+
+  double scan_miss;
+  double scan_hit;
+  double free_miss;
+  double hit_exponential_coeff;
+};
+}  // namespace lidar_layer
+
+#endif  // SRC_LIDAR_CONFIG_H

--- a/igvc_navigation/src/mapper/lidar_layer.cpp
+++ b/igvc_navigation/src/mapper/lidar_layer.cpp
@@ -1,0 +1,31 @@
+#include "lidar_layer.h"
+namespace lidar_layer
+{
+LidarLayer::LidarLayer() : private_nh_{ "~" }
+{
+  initializeGridmap();
+}
+
+void LidarLayer::initializeGridmap()
+{
+  map_.setFrameId();
+}
+
+void LidarLayer::onInitialize()
+{
+  Layer::onInitialize();
+}
+
+void LidarLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, double *min_x, double *min_y,
+                              double *max_x, double *max_y)
+{
+  // TODO: Change this to only the points that have been updated
+  map.
+}
+
+void LidarLayer::updateCosts(costmap_2d::Costmap2D &master_grid, int min_i, int min_j, int max_i, int max_j)
+{
+  Layer::updateCosts(master_grid, min_i, min_j, max_i, max_j);
+}
+
+}  // namespace lidar_layer

--- a/igvc_navigation/src/mapper/lidar_layer.cpp
+++ b/igvc_navigation/src/mapper/lidar_layer.cpp
@@ -236,7 +236,7 @@ void LidarLayer::markScanHit(const grid_map::Index &index, const grid_map::Posit
   const auto coeff = config_.lidar.hit_exponential_coeff;
   const double probability = std::exp(-coeff * distance) * config_.lidar.scan_hit;
 
-  (*layer_)(index[0], index[1]) += static_cast<float>(probability_utils::toLogOdds(probability));
+  (*layer_)(index[0], index[1]) = std::min((*layer_)(index[0], index[1]) + probability, config_.map.max_occupancy);
 }
 
 void LidarLayer::updateMapTimestamp(const ros::Time &stamp)

--- a/igvc_navigation/src/mapper/lidar_layer.cpp
+++ b/igvc_navigation/src/mapper/lidar_layer.cpp
@@ -1,31 +1,247 @@
 #include "lidar_layer.h"
+#include <mapper/probability_utils.h>
+#include <pcl_ros/transforms.h>
+#include <pluginlib/class_list_macros.h>
+#include "map_config.h"
+
+PLUGINLIB_EXPORT_CLASS(lidar_layer::LidarLayer, costmap_2d::Layer)
+
 namespace lidar_layer
 {
-LidarLayer::LidarLayer() : private_nh_{ "~" }
+LidarLayer::LidarLayer() : private_nh_{ "~" }, map_{ { logodds_layer, probability_layer } }, config_{ private_nh_ }
 {
-  initializeGridmap();
+  initGridmap();
+  initPubSub();
+  costmap_2d_ = { static_cast<unsigned int>(map_.getSize()[0]), static_cast<unsigned int>(map_.getSize()[1]),
+                  map_.getResolution(), map_.getPosition()[0], map_.getPosition()[1] };
 }
 
-void LidarLayer::initializeGridmap()
+void LidarLayer::initGridmap()
 {
-  map_.setFrameId();
+  // TODO: Configurable start positions
+  map_.setFrameId(config_.map.frame_id);
+  grid_map::Length dimensions{ config_.map.length_x, config_.map.length_y };
+  map_.setGeometry(dimensions, config_.map.resolution);
+  layer_ = &map_.get(logodds_layer);
+  (*layer_).setZero();
+
+  grid_map::Position top_left;
+  map_.getPosition(map_.getStartIndex(), top_left);
+}
+
+void LidarLayer::initPubSub()
+{
+  occupied_sub_ = nh_.subscribe(config_.lidar.occupied_topic, 1, &LidarLayer::occupiedCallback, this);
+  free_sub_ = nh_.subscribe(config_.lidar.free_topic, 1, &LidarLayer::freeCallback, this);
+  gridmap_pub_ = nh_.advertise<grid_map_msgs::GridMap>(config_.map.debug.map_topic, 1);
 }
 
 void LidarLayer::onInitialize()
 {
-  Layer::onInitialize();
 }
 
 void LidarLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, double *min_x, double *min_y,
                               double *max_x, double *max_y)
 {
   // TODO: Change this to only the points that have been updated
-  map.
+  *min_x = map_.getPosition()[0] - map_.getLength()[0] / 2;
+  *max_x = map_.getPosition()[0] + map_.getLength()[0] / 2;
+  *min_y = map_.getPosition()[1] - map_.getLength()[1] / 2;
+  *max_y = map_.getPosition()[1] + map_.getLength()[1] / 2;
 }
 
-void LidarLayer::updateCosts(costmap_2d::Costmap2D &master_grid, int min_i, int min_j, int max_i, int max_j)
+void LidarLayer::updateCosts(costmap_2d::Costmap2D &master_grid, int /*min_i*/, int /*min_j*/, int /*max_i*/,
+                             int /*max_j*/)
 {
-  Layer::updateCosts(master_grid, min_i, min_j, max_i, max_j);
+  updateProbabilityLayer();
+  transferToCostmap();
+  debugPublishMap();
+
+  assert(costmap_2d_.getSizeInCellsX() == master_grid.getSizeInCellsX());
+  assert(costmap_2d_.getSizeInCellsY() == master_grid.getSizeInCellsY());
+
+  size_t num_cells = costmap_2d_.getSizeInCellsX() * costmap_2d_.getSizeInCellsY();
+
+  uchar *master_array = master_grid.getCharMap();
+  uchar *lidar_array = costmap_2d_.getCharMap();
+  for (size_t i = 0; i < num_cells; i++)
+  {
+    uchar old_cost = master_array[i];
+    if (old_cost == costmap_2d::NO_INFORMATION || old_cost < lidar_array[i])
+    {
+      master_array[i] = lidar_array[i];
+    }
+  }
+}
+
+void LidarLayer::updateProbabilityLayer()
+{
+  map_.get(probability_layer) = layer_->unaryExpr(&probability_utils::fromLogOdds<float>);
+}
+
+void LidarLayer::transferToCostmap()
+{
+  ROS_ASSERT(map_.getSize()[0] == static_cast<int>(costmap_2d_.getSizeInCellsX()));
+  ROS_ASSERT(map_.getSize()[1] == static_cast<int>(costmap_2d_.getSizeInCellsY()));
+  ROS_ASSERT(map_.getResolution() == costmap_2d_.getResolution());
+
+  size_t num_cells = map_.getSize().prod();
+
+  uchar *char_map = costmap_2d_.getCharMap();
+
+  const grid_map::Matrix &prob_layer = map_.get(probability_layer);
+
+  for (grid_map::GridMapIterator it{ map_ }; !it.isPastEnd(); ++it)
+  {
+    float probability = prob_layer((*it)(0), (*it)(1));
+
+    uchar costmap_value;
+    if (probability > config_.map.occupied_threshold)
+    {
+      costmap_value = costmap_2d::LETHAL_OBSTACLE;
+    }
+    else
+    {
+      costmap_value = costmap_2d::FREE_SPACE;
+    }
+    size_t index = grid_map::getLinearIndexFromIndex(it.getUnwrappedIndex(), map_.getSize(), false);
+    // Reverse cell order because of different conventions between occupancy grid and grid map.
+    char_map[num_cells - index - 1] = costmap_value;
+  }
+}
+
+void LidarLayer::occupiedCallback(const sensor_msgs::PointCloud2ConstPtr &occupied_pc)
+{
+  const auto [cloud, transform] = getCloudAndTransform(occupied_pc);
+  insertScan(cloud, transform);
+  updateMapTimestamp(occupied_pc->header.stamp);
+}
+
+void LidarLayer::freeCallback(const sensor_msgs::PointCloud2ConstPtr &free_pc)
+{
+  const auto [cloud, transform] = getCloudAndTransform(free_pc);
+  insertFreeSpace(cloud, transform);
+  updateMapTimestamp(free_pc->header.stamp);
+}
+
+void LidarLayer::debugPublishMap()
+{
+  map_.setTimestamp(ros::Time::now().toNSec());
+  grid_map_msgs::GridMap message;
+  grid_map::GridMapRosConverter::toMessage(map_, message);
+  gridmap_pub_.publish(message);
+}
+
+std::pair<pcl::PointCloud<pcl::PointXYZ>, geometry_msgs::TransformStamped>
+LidarLayer::getCloudAndTransform(const sensor_msgs::PointCloud2ConstPtr &pc)
+{
+  auto map_frame = config_.map.frame_id;
+  auto pc_frame = pc->header.frame_id;
+  ros::Time cloud_stamp = pc->header.stamp;
+
+  // TODO: Make the timeout a parameter
+  if (!tf_->canTransform(map_frame, pc_frame, cloud_stamp, ros::Duration(1.0)))
+  {
+    ROS_WARN_STREAM_THROTTLE_NAMED(1.0, "pc_transform_timeout",
+                                   "Failed to find transform for pointcloud from frame '"
+                                       << pc_frame << "' to frame '" << map_frame
+                                       << "' within timeout. Using latest transform...");
+    cloud_stamp = ros::Time(0);
+  }
+
+  sensor_msgs::PointCloud2 transformed_cloud;
+  geometry_msgs::TransformStamped transform =
+      tf_->lookupTransform(map_frame, pc_frame, cloud_stamp, ros::Duration(0.1));
+  tf2::doTransform(*pc, transformed_cloud, transform);
+
+  pcl::PointCloud<pcl::PointXYZ> pcl_cloud;
+  pcl::fromROSMsg(transformed_cloud, pcl_cloud);
+
+  return std::make_pair(pcl_cloud, transform);
+}
+
+void LidarLayer::insertScan(const LidarLayer::PointCloud &pointcloud,
+                            const geometry_msgs::TransformStamped &lidar_transform)
+{
+  double lidar_x = lidar_transform.transform.translation.x;
+  double lidar_y = lidar_transform.transform.translation.y;
+  grid_map::Position lidar_pos{ lidar_x, lidar_y };
+
+  std::unordered_set<grid_map::Index> free_cells{};
+  free_cells.reserve(50 * pointcloud.size());
+  last_occupied_cells_.clear();
+  last_occupied_cells_.reserve(pointcloud.size());
+
+  for (const auto &point : pointcloud)
+  {
+    grid_map::Position end_point{ point.x, point.y };
+    grid_map::Index end_index;
+    map_.getIndex(end_point, end_index);
+
+    for (grid_map::LineIterator it{ map_, lidar_pos, end_point }; !it.isPastEnd(); ++it)
+    {
+      free_cells.emplace(*it);
+      // Break when iterator gets to the actual cell
+      if (end_index[0] == (*it)[0] && end_index[1] == (*it)[1])
+      {
+        break;
+      }
+    }
+    markScanHit(end_index, end_point, lidar_pos);
+    last_occupied_cells_.emplace(end_index);
+  }
+
+  for (const auto &index : free_cells)
+  {
+    markScanMiss(index);
+  }
+}
+
+void LidarLayer::insertFreeSpace(const PointCloud &pointcloud, const geometry_msgs::TransformStamped &lidar_transform)
+{
+  assert(pointcloud.size() % 2 == 0);
+
+  double lidar_x = lidar_transform.transform.translation.x;
+  double lidar_y = lidar_transform.transform.translation.y;
+  grid_map::Position lidar_pos{ lidar_x, lidar_y };
+
+  std::unordered_set<grid_map::Index> free_cells{};
+  free_cells.reserve(50 * pointcloud.size());
+
+  for (size_t i = 0; i < pointcloud.size(); i += 2)
+  {
+    // points for free space are pairs of (min_range, endpoint)
+    const auto &startpoint = pointcloud.points[i];
+    const auto &endpoint = pointcloud.points[i + 1];
+
+    grid_map::Position startpoint_pos{ startpoint.x, startpoint.y };
+    grid_map::Position endpoint_pos{ endpoint.x, endpoint.y };
+
+    for (grid_map::LineIterator it{ map_, startpoint_pos, endpoint_pos }; !it.isPastEnd(); ++it)
+    {
+      free_cells.emplace(*it);
+    }
+  }
+
+  for (const auto &index : free_cells)
+  {
+    markFreeMiss(index);
+  }
+}
+
+void LidarLayer::markScanHit(const grid_map::Index &index, const grid_map::Position &point,
+                             const grid_map::Position &lidar_pos)
+{
+  const double distance = (lidar_pos - point).norm();
+  const auto coeff = config_.lidar.hit_exponential_coeff;
+  const double probability = std::exp(-coeff * distance) * config_.lidar.scan_hit;
+
+  (*layer_)(index[0], index[1]) += static_cast<float>(probability_utils::toLogOdds(probability));
+}
+
+void LidarLayer::updateMapTimestamp(const ros::Time &stamp)
+{
+  map_.setTimestamp(stamp.toNSec());
 }
 
 }  // namespace lidar_layer

--- a/igvc_navigation/src/mapper/lidar_layer.h
+++ b/igvc_navigation/src/mapper/lidar_layer.h
@@ -1,0 +1,29 @@
+#ifndef SRC_LIDAR_LAYER_H
+#define SRC_LIDAR_LAYER_H
+
+#include <costmap_2d/GenericPluginConfig.h>
+#include <costmap_2d/layer.h>
+#include <costmap_2d/layered_costmap.h>
+
+#include <grid_map_ros/grid_map_ros.hpp>
+
+namespace lidar_layer
+{
+class LidarLayer : public costmap_2d::Layer
+{
+public:
+  LidarLayer();
+
+  void onInitialize() override;
+  void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y, double* max_x,
+                    double* max_y) override;
+  void updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j) override;
+private:
+  ros::NodeHandle private_nh_;
+  grid_map::GridMap map_{ { "lidar" } };
+
+  void initializeGridmap();
+};
+}  // namespace lidar_layer
+
+#endif  // SRC_LIDAR_LAYER_H

--- a/igvc_navigation/src/mapper/lidar_layer.h
+++ b/igvc_navigation/src/mapper/lidar_layer.h
@@ -1,28 +1,84 @@
 #ifndef SRC_LIDAR_LAYER_H
 #define SRC_LIDAR_LAYER_H
 
+#include <unordered_set>
+
 #include <costmap_2d/GenericPluginConfig.h>
 #include <costmap_2d/layer.h>
 #include <costmap_2d/layered_costmap.h>
 
+#include <pcl_ros/point_cloud.h>
 #include <grid_map_ros/grid_map_ros.hpp>
+
+#include "eigen_hash.h"
+#include "lidar_layer_config.h"
 
 namespace lidar_layer
 {
 class LidarLayer : public costmap_2d::Layer
 {
 public:
+  using PointCloud = pcl::PointCloud<pcl::PointXYZ>;
   LidarLayer();
 
   void onInitialize() override;
   void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y, double* max_x,
                     double* max_y) override;
   void updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j) override;
-private:
-  ros::NodeHandle private_nh_;
-  grid_map::GridMap map_{ { "lidar" } };
 
-  void initializeGridmap();
+private:
+  static constexpr auto logodds_layer = "logodds";
+  static constexpr auto probability_layer = "probability";
+  ros::NodeHandle nh_;
+  ros::NodeHandle private_nh_;
+  grid_map::GridMap map_;
+  grid_map::Matrix* layer_{};
+  LidarLayerConfig config_;
+
+  ros::Subscriber occupied_sub_;
+  ros::Subscriber free_sub_;
+  ros::Publisher gridmap_pub_;
+
+  std::unordered_set<grid_map::Index> last_occupied_cells_{};
+
+  costmap_2d::Costmap2D costmap_2d_{};
+
+  void initGridmap();
+  void initPubSub();
+
+  void occupiedCallback(const sensor_msgs::PointCloud2ConstPtr& occupied_pc);
+  void freeCallback(const sensor_msgs::PointCloud2ConstPtr& free_pc);
+
+  void insertScan(const PointCloud& pointcloud, const geometry_msgs::TransformStamped& lidar_transform);
+
+  void insertFreeSpace(const PointCloud& pointcloud, const geometry_msgs::TransformStamped& lidar_transform);
+
+  /**
+   * Returns a transformed pointcloud, as well as a transform to base_footprint
+   * @param pc pointcloud to be transformed
+   * @return a std::pair of the transformed pointcloud and the transform to base_footprint
+   */
+  [[nodiscard]] std::pair<PointCloud, geometry_msgs::TransformStamped>
+  getCloudAndTransform(const sensor_msgs::PointCloud2ConstPtr& pc);
+
+  void updateMapTimestamp(const ros::Time& stamp);
+
+  void updateProbabilityLayer();
+  void transferToCostmap();
+
+  void debugPublishMap();
+
+  inline void markScanMiss(const grid_map::Index& index)
+  {
+    (*layer_)(index[0], index[1]) += config_.lidar.scan_miss;
+  }
+
+  void markScanHit(const grid_map::Index& index, const grid_map::Position& point, const grid_map::Position& lidar_pos);
+
+  inline void markFreeMiss(const grid_map::Index& index)
+  {
+    (*layer_)(index[0], index[1]) += config_.lidar.free_miss;
+  }
 };
 }  // namespace lidar_layer
 

--- a/igvc_navigation/src/mapper/lidar_layer.h
+++ b/igvc_navigation/src/mapper/lidar_layer.h
@@ -70,14 +70,16 @@ private:
 
   inline void markScanMiss(const grid_map::Index& index)
   {
-    (*layer_)(index[0], index[1]) += config_.lidar.scan_miss;
+    (*layer_)(index[0], index[1]) =
+        std::max((*layer_)(index[0], index[1]) + config_.lidar.scan_miss, config_.map.min_occupancy);
   }
 
   void markScanHit(const grid_map::Index& index, const grid_map::Position& point, const grid_map::Position& lidar_pos);
 
   inline void markFreeMiss(const grid_map::Index& index)
   {
-    (*layer_)(index[0], index[1]) += config_.lidar.free_miss;
+    (*layer_)(index[0], index[1]) =
+        std::max((*layer_)(index[0], index[1]) + config_.lidar.free_miss, config_.map.min_occupancy);
   }
 };
 }  // namespace lidar_layer

--- a/igvc_navigation/src/mapper/lidar_layer_config.cpp
+++ b/igvc_navigation/src/mapper/lidar_layer_config.cpp
@@ -1,0 +1,1 @@
+#include "lidar_layer_config.h"

--- a/igvc_navigation/src/mapper/lidar_layer_config.cpp
+++ b/igvc_navigation/src/mapper/lidar_layer_config.cpp
@@ -1,1 +1,11 @@
 #include "lidar_layer_config.h"
+
+#include <parameter_assertions/assertions.h>
+
+namespace lidar_layer
+{
+LidarLayerConfig::LidarLayerConfig(const ros::NodeHandle &parent_nh)
+  : nh{ parent_nh, "lidar_layer" }, map{ nh }, lidar{ nh }
+{
+}
+}  // namespace lidar_layer

--- a/igvc_navigation/src/mapper/lidar_layer_config.h
+++ b/igvc_navigation/src/mapper/lidar_layer_config.h
@@ -1,12 +1,22 @@
 #ifndef SRC_LIDAR_LAYER_CONFIG_H
 #define SRC_LIDAR_LAYER_CONFIG_H
 
+#include <ros/ros.h>
+#include "lidar_config.h"
+#include "map_config.h"
+
 namespace lidar_layer
 {
 class LidarLayerConfig
 {
+public:
+  explicit LidarLayerConfig(const ros::NodeHandle& parent_nh);
 
+  ros::NodeHandle nh;
+
+  MapConfig map;
+  LidarConfig lidar;
 };
-}
+}  // namespace lidar_layer
 
-#endif //SRC_LIDAR_LAYER_CONFIG_H
+#endif  // SRC_LIDAR_LAYER_CONFIG_H

--- a/igvc_navigation/src/mapper/lidar_layer_config.h
+++ b/igvc_navigation/src/mapper/lidar_layer_config.h
@@ -1,0 +1,12 @@
+#ifndef SRC_LIDAR_LAYER_CONFIG_H
+#define SRC_LIDAR_LAYER_CONFIG_H
+
+namespace lidar_layer
+{
+class LidarLayerConfig
+{
+
+};
+}
+
+#endif //SRC_LIDAR_LAYER_CONFIG_H

--- a/igvc_navigation/src/mapper/map_config.cpp
+++ b/igvc_navigation/src/mapper/map_config.cpp
@@ -14,7 +14,11 @@ MapConfig::MapConfig(const ros::NodeHandle &parent_nh)
 
   assertions::getParam(nh, "frame_id", frame_id);
   assertions::getParam(nh, "occupied_threshold", occupied_threshold);
-  //  occupied_threshold = probability_utils::toLogOdds(occupied_threshold);
+
+  assertions::getParam(nh, "max_occupancy", max_occupancy);
+  max_occupancy = probability_utils::toLogOdds(max_occupancy);
+  assertions::getParam(nh, "min_occupancy", min_occupancy);
+  min_occupancy = probability_utils::toLogOdds(min_occupancy);
 
   assertions::getParam(nh, "debug/map_topic", debug.map_topic);
 }

--- a/igvc_navigation/src/mapper/map_config.cpp
+++ b/igvc_navigation/src/mapper/map_config.cpp
@@ -1,0 +1,21 @@
+#include "map_config.h"
+#include <mapper/probability_utils.h>
+#include <parameter_assertions/assertions.h>
+
+namespace lidar_layer
+{
+MapConfig::MapConfig(const ros::NodeHandle &parent_nh)
+{
+  ros::NodeHandle nh{ parent_nh, "map" };
+
+  assertions::getParam(nh, "resolution", resolution);
+  assertions::getParam(nh, "length_x", length_x);
+  assertions::getParam(nh, "length_y", length_y);
+
+  assertions::getParam(nh, "frame_id", frame_id);
+  assertions::getParam(nh, "occupied_threshold", occupied_threshold);
+  //  occupied_threshold = probability_utils::toLogOdds(occupied_threshold);
+
+  assertions::getParam(nh, "debug/map_topic", debug.map_topic);
+}
+}  // namespace lidar_layer

--- a/igvc_navigation/src/mapper/map_config.h
+++ b/igvc_navigation/src/mapper/map_config.h
@@ -14,6 +14,9 @@ public:
   double length_x;
   double length_y;
 
+  double max_occupancy;
+  double min_occupancy;
+
   std::string frame_id;
 
   double occupied_threshold;

--- a/igvc_navigation/src/mapper/map_config.h
+++ b/igvc_navigation/src/mapper/map_config.h
@@ -1,0 +1,28 @@
+#ifndef SRC_MAP_CONFIG_H
+#define SRC_MAP_CONFIG_H
+
+#include <ros/ros.h>
+
+namespace lidar_layer
+{
+class MapConfig
+{
+public:
+  MapConfig(const ros::NodeHandle& parent_nh);
+
+  double resolution;
+  double length_x;
+  double length_y;
+
+  std::string frame_id;
+
+  double occupied_threshold;
+
+  struct
+  {
+    std::string map_topic;
+  } debug;
+};
+}  // namespace lidar_layer
+
+#endif  // SRC_MAP_CONFIG_H

--- a/igvc_perception/config/pointcloud_filter.yaml
+++ b/igvc_perception/config/pointcloud_filter.yaml
@@ -13,8 +13,9 @@ pointcloud_filter:
         height_min: 0.4
         height_max: 1.2
     raycast_filter:
+        min_range: 2.0
         end_distance: 10
-        angular_resolution: 0.01
+        angular_resolution: 0.02
         start_angle: -2.0
         end_angle: 2.0
     frames:

--- a/igvc_perception/include/pointcloud_filter/raycast_filter/raycast_filter.h
+++ b/igvc_perception/include/pointcloud_filter/raycast_filter/raycast_filter.h
@@ -19,7 +19,7 @@ public:
   void filter(Bundle& bundle) override;
 
 private:
-  RaycastFilterConfig config_{};
+  RaycastFilterConfig config_;
 
   int discretize(double angle) const;
 };

--- a/igvc_perception/include/pointcloud_filter/raycast_filter/raycast_filter_config.h
+++ b/igvc_perception/include/pointcloud_filter/raycast_filter/raycast_filter_config.h
@@ -11,9 +11,9 @@ struct RaycastFilterConfig
   double angular_resolution = 0.0;
   double start_angle = 0.0;
   double end_angle = 0.0;
+  double min_range = 0.0;
 
-  RaycastFilterConfig() = default;
-  RaycastFilterConfig(const ros::NodeHandle& nh);
+  explicit RaycastFilterConfig(const ros::NodeHandle& nh);
 };
 }  // namespace pointcloud_filter
 

--- a/igvc_perception/src/pointcloud_filter/pointcloud_filter.cpp
+++ b/igvc_perception/src/pointcloud_filter/pointcloud_filter.cpp
@@ -52,9 +52,6 @@ void PointcloudFilter::pointcloudCallback(const PointCloud::ConstPtr& raw_pointc
 
   tf_transform_filter_.transform(*bundle.occupied_pointcloud, *bundle.occupied_pointcloud, lidar_frame, timeout);
   raycast_filter_.filter(bundle);
-  tf_transform_filter_.transform(*bundle.occupied_pointcloud, *bundle.occupied_pointcloud, base_frame, timeout);
-
-  bundle.free_pointcloud->header.frame_id = base_frame;
 
   transformed_pointcloud_pub_.publish(bundle.pointcloud);
   occupied_pointcloud_pub_.publish(bundle.occupied_pointcloud);

--- a/igvc_perception/src/pointcloud_filter/raycast_filter/raycast_filter.cpp
+++ b/igvc_perception/src/pointcloud_filter/raycast_filter/raycast_filter.cpp
@@ -11,6 +11,7 @@ void RaycastFilter::filter(pointcloud_filter::Bundle& bundle)
 {
   // Precondition: bundle.occupied_pointcloud has lidar frame
 
+  const auto& min_range = config_.min_range;
   const auto& end_distance = config_.end_distance;
   const auto& start_angle = config_.start_angle;
   const auto& end_angle = config_.end_angle;
@@ -35,10 +36,18 @@ void RaycastFilter::filter(pointcloud_filter::Bundle& bundle)
     if (discretized_angles.find(i) == discretized_angles.end())
     {
       double angle = i * angular_resolution;
-      auto x = static_cast<float>(end_distance * cos(angle));
-      auto y = static_cast<float>(end_distance * sin(angle));
-      velodyne_pointcloud::PointXYZIR raycasted_point{ { { x, y, 0.0, 0.0 } }, 0.0, 0 };
-      bundle.free_pointcloud->points.emplace_back(raycasted_point);
+      {
+        auto x = static_cast<float>(min_range * cos(angle));
+        auto y = static_cast<float>(min_range * sin(angle));
+        velodyne_pointcloud::PointXYZIR min_range_point{ { { x, y, 0.0, 0.0 } }, 0.0, 0 };
+        bundle.free_pointcloud->points.emplace_back(min_range_point);
+      }
+      {
+        auto x = static_cast<float>(end_distance * cos(angle));
+        auto y = static_cast<float>(end_distance * sin(angle));
+        velodyne_pointcloud::PointXYZIR raycasted_point{ { { x, y, 0.0, 0.0 } }, 0.0, 0 };
+        bundle.free_pointcloud->points.emplace_back(raycasted_point);
+      }
     }
   }
 

--- a/igvc_perception/src/pointcloud_filter/raycast_filter/raycast_filter_config.cpp
+++ b/igvc_perception/src/pointcloud_filter/raycast_filter/raycast_filter_config.cpp
@@ -9,6 +9,7 @@ RaycastFilterConfig::RaycastFilterConfig(const ros::NodeHandle &nh)
 
   assertions::getParam(child_nh, "end_distance", end_distance);
   assertions::getParam(child_nh, "angular_resolution", angular_resolution);
+  assertions::getParam(child_nh, "min_range", min_range);
   assertions::getParam(child_nh, "start_angle", start_angle);
   assertions::getParam(child_nh, "end_angle", end_angle);
 }


### PR DESCRIPTION
# Description
With the refactor to move base flex, we needed to move our mapping stack to `costmap_2d`. The design document for this refactor was outlined in #483, and the issue for the refactor in #487. However, while writing the first `lidar_layer`, I realized that this would be quite a large PR, and so I decided to split the issue into the two parts: `lidar_layer` and `line_layer`.

While I originally decided to write my own array for the backing structure, I came across [gridmap](https://github.com/ANYbotics/grid_map), which seems to be a nice library to use for 2d grid maps. As a result, I have added `grid_map` as a dependency and used that instead. 

To keep maintain compatibility, a `refactored_mapper.launch` launch file has been created that  launches the new `lidar_layer` instead of the old `wrapper_layer`. Since the path planner hasn't been migrated yet (rip issues) and #496 hasn't been merged in yet, we can't actually run the full navigation stuck using this new `lidar_layer` yet.

This PR does the following:
- Creates a `line_layer` `costmap_2d::Layer` that follows the design document
- Create a new `refactored_local_costmap_params.yaml` file that loads the new `line_layer` as a local planner and has some params.
- Adds `grid_map` as a dependency to our stack

Fixes #513

# Testing steps (If relevant)
## New `line_layer` does as expected
1. Run simulation. `roslaunch igvc_gazebo qualification.launch`. Add a few barrels in front of the robot
2. Run the new `lidar_layer`. `roslaunch igvc_navigation refactored_mapper.launch`
3. Open up rviz and add a display of type `Map` for the topic `/move_base_flex/local_costmap/costmap`.
4. Optional: Since the `costmap` viz is pretty bad and discretizes everything, to view the undescritized probabilities, do `roslaunch igvc_navigation gridmap_viz.launch` and add a display of type `Map` for the topic `/grid_map_visualization/occupancy_grid`. You should see a (slightly less crappy) visualization that properly shows the 0.0 - 1.0 occupancy probabilities (although its hard to judge where 0.5 is).

Expectation: The places where the barrels are marked as occupied in the map (whichever one you choose to use). If you take the barrels away, then occupancy mapping happens and after a while the place is marked as free space.

Note: The above behaviour only really happens because the occupancy probabilities are capped at 0.01 and 0.99. This is located in the `refactored_local_costmap_params.yaml` file.

Also, please review this PR locally, as imo it's kind of hard to review large changes on github.

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
