### PR TITLE
Changes camera frame + topics to use namespaces more, clean up segmented image and camera_info topic, adds camera intrinsics matrix scaling and publishing for sim_detector

### DIFF
--- a/igvc_description/urdf/jessii.urdf.xacro
+++ b/igvc_description/urdf/jessii.urdf.xacro
@@ -257,7 +257,7 @@
   </xacro:macro>
 
 
-  <link name="center_cam">
+  <link name="cam/center">
       <visual>
           <geometry>
               <box size="0.1 0.1 0.1"/>
@@ -268,19 +268,19 @@
   <joint name="magnetometer_to_center_cam" type="fixed">
       <origin xyz="${center_camera_x} ${center_camera_y} ${center_camera_z}" rpy="0 ${center_camera_pitch} 0" />
       <parent link="magnetometer"/>
-      <child link="center_cam"/>
+      <child link="cam/center"/>
   </joint>
 
   <!-- the optical joint is in the correct frame for transforms -->
   <link name="cam/center_optical"/>
 
   <joint name="cam/center_optical_joint" type="fixed">
-      <parent link="center_cam"/>
+      <parent link="cam/center"/>
       <child link="cam/center_optical"/>
       <origin xyz="0 0 0" rpy="-1.5708 0 -1.5708"/>
   </joint>
 
-  <gazebo reference="center_cam">
+  <gazebo reference="cam/center">
       <sensor name="center_cam_sensor" type="camera">
           <camera>
               <!-- hov in radians -->
@@ -309,8 +309,8 @@
           <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
               <alwaysOn>true</alwaysOn>
               <updateRate>30</updateRate>
-              <cameraName>cam/center</cameraName>
-              <imageTopicName>image_raw</imageTopicName>
+              <cameraName>cam/center/raw</cameraName>
+              <imageTopicName>image</imageTopicName>
               <cameraInfoTopicName>camera_info</cameraInfoTopicName>
               <frameName>cam/center_optical</frameName>
               <hackBaseline>0.0</hackBaseline>
@@ -323,7 +323,7 @@
       </sensor>
   </gazebo>
 
-  <link name="right_cam">
+  <link name="cam/right">
       <visual>
           <geometry>
               <box size="0.1 0.1 0.1"/>
@@ -334,19 +334,19 @@
   <joint name="magnetometer_to_right_cam" type="fixed">
       <origin xyz="${right_camera_x} ${right_camera_y} ${right_camera_z}" rpy="0 ${right_camera_pitch} ${right_camera_yaw}" />
       <parent link="magnetometer"/>
-      <child link="right_cam"/>
+      <child link="cam/right"/>
   </joint>
 
   <!-- the optical joint is in the correct frame for transforms -->
   <link name="cam/right_optical"/>
 
   <joint name="cam/right_optical_joint" type="fixed">
-      <parent link="right_cam"/>
+      <parent link="cam/right"/>
       <child link="cam/right_optical"/>
       <origin xyz="0 0 0" rpy="-1.5708 0 -1.5708"/>
   </joint>
 
-  <gazebo reference="right_cam">
+  <gazebo reference="cam/right">
       <sensor name="right_cam_sensor" type="camera">
           <camera>
               <!-- hov in radians -->
@@ -375,8 +375,8 @@
           <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
               <alwaysOn>true</alwaysOn>
               <updateRate>30</updateRate>
-              <cameraName>cam/right</cameraName>
-              <imageTopicName>image_raw</imageTopicName>
+              <cameraName>cam/right/raw</cameraName>
+              <imageTopicName>image</imageTopicName>
               <cameraInfoTopicName>camera_info</cameraInfoTopicName>
               <frameName>cam/right_optical</frameName>
               <hackBaseline>0.0</hackBaseline>
@@ -389,7 +389,7 @@
       </sensor>
   </gazebo>
 
-  <link name="left_cam">
+  <link name="cam/left">
       <visual>
           <geometry>
               <box size="0.1 0.1 0.1"/>
@@ -400,19 +400,19 @@
   <joint name="magnetometer_to_left_cam" type="fixed">
       <origin xyz="${left_camera_x} ${left_camera_y} ${left_camera_z}" rpy="0 ${left_camera_pitch} ${left_camera_yaw}" />
       <parent link="magnetometer"/>
-      <child link="left_cam"/>
+      <child link="cam/left"/>
   </joint>
 
   <!-- the optical joint is in the correct frame for transforms -->
   <link name="cam/left_optical"/>
 
   <joint name="cam/left_optical_joint" type="fixed">
-      <parent link="left_cam"/>
+      <parent link="cam/left"/>
       <child link="cam/left_optical"/>
       <origin xyz="0 0 0" rpy="-1.5708 0 -1.5708"/>
   </joint>
 
-  <gazebo reference="left_cam">
+  <gazebo reference="cam/left">
       <sensor name="left_cam_sensor" type="camera">
           <camera>
               <!-- hov in radians -->
@@ -441,8 +441,8 @@
           <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
               <alwaysOn>true</alwaysOn>
               <updateRate>30</updateRate>
-              <cameraName>cam/left</cameraName>
-              <imageTopicName>image_raw</imageTopicName>
+              <cameraName>cam/left/raw</cameraName>
+              <imageTopicName>image</imageTopicName>
               <cameraInfoTopicName>camera_info</cameraInfoTopicName>
               <frameName>cam/left_optical</frameName>
               <hackBaseline>0.0</hackBaseline>

--- a/igvc_gazebo/launch/sim_detector.launch
+++ b/igvc_gazebo/launch/sim_detector.launch
@@ -8,11 +8,13 @@
       <rosparam param="semantic_topic_prefix">["/cam/center", "/cam/left", "/cam/right"]</rosparam>
       <rosparam param="semantic_topic_suffix">["", "", ""]</rosparam>
 
+      <param name="image_base_topic" value="/raw/image" />
+
       <param name="output_image/width" value="400" />
       <param name="output_image/height" value="400" />
 
       <!-- names of output segmentation topics. Published in the namespace of the corresponding camera -->
-      <param name="line_topic" value="/semantic_segmentation" />
+      <param name="line_topic" value="/segmented/image" />
       <param name="barrel_topic" value="/detected_barrels" />
   </node>
 

--- a/igvc_gazebo/nodes/sim_color_detector/main.cpp
+++ b/igvc_gazebo/nodes/sim_color_detector/main.cpp
@@ -14,14 +14,20 @@
 #include <opencv2/core/mat.hpp>
 #include <opencv2/opencv.hpp>
 
+#include <image_transport/image_transport.h>
 #include <parameter_assertions/assertions.h>
 #include <map>
 #include <vector>
 
 using Pixel = cv::Point3_<uint8_t>;
+struct LineBarrelPair
+{
+  image_transport::CameraPublisher camera;
+  ros::Publisher barrel;
+};
 
 // map of camera name to line and barrel publishers
-std::map<std::string, std::vector<ros::Publisher>> g_pubs;
+std::map<std::string, LineBarrelPair> g_pubs;
 
 // Output size of the image
 cv::Size g_output_size;
@@ -79,11 +85,36 @@ bool color_check(const Pixel* pixel, Color desired_color)
   return false;
 }
 
+sensor_msgs::CameraInfo scaleCameraInfo(const sensor_msgs::CameraInfo& camera_info, int width, int height)
+{
+  sensor_msgs::CameraInfo changed_camera_info = camera_info;
+  changed_camera_info.D = camera_info.D;
+  changed_camera_info.distortion_model = camera_info.distortion_model;
+  changed_camera_info.R = camera_info.R;
+  changed_camera_info.roi = camera_info.roi;
+  changed_camera_info.binning_x = camera_info.binning_x;
+  changed_camera_info.binning_y = camera_info.binning_y;
+
+  double w_ratio = static_cast<double>(width) / static_cast<double>(camera_info.width);
+  double h_ratio = static_cast<double>(height) / static_cast<double>(camera_info.height);
+
+  changed_camera_info.width = static_cast<unsigned int>(width);
+  changed_camera_info.height = static_cast<unsigned int>(height);
+
+  changed_camera_info.K = { { camera_info.K[0] * w_ratio, 0, camera_info.K[2] * w_ratio, 0, camera_info.K[4] * h_ratio,
+                              camera_info.K[5] * h_ratio, 0, 0, 1 } };
+  changed_camera_info.P = { { camera_info.P[0] * w_ratio, 0, camera_info.P[2] * w_ratio, 0, 0,
+                              camera_info.P[5] * h_ratio, camera_info.P[6] * h_ratio, 0, 0, 0, 1, 0 } };
+
+  return changed_camera_info;
+}
+
 /**
 Recieves an input image and publishes two segmented images: one for lines and
 another for barrels
 */
-void handleImage(const sensor_msgs::ImageConstPtr& msg, std::string camera_name)
+void handleImage(const sensor_msgs::ImageConstPtr& msg, const sensor_msgs::CameraInfoConstPtr& camera_info,
+                 std::string camera_name)
 {
   cv_bridge::CvImagePtr cv_ptr;
   cv::Mat frame;  // Input image
@@ -134,15 +165,19 @@ void handleImage(const sensor_msgs::ImageConstPtr& msg, std::string camera_name)
   outmsg.header = msg->header;
   cv_ptr->encoding = "mono8";
 
+  // Modify camera info to fit scaled image
+  sensor_msgs::CameraInfo modified_camera_info =
+      scaleCameraInfo(*camera_info, g_output_size.width, g_output_size.height);
+
   // publish line segmentation
   cv_ptr->image = output_lines;
   cv_ptr->toImageMsg(outmsg);
-  g_pubs.at(camera_name).at(0).publish(outmsg);
+  g_pubs.at(camera_name).camera.publish(outmsg, modified_camera_info);
 
   // publish barrel segmentation
   cv_ptr->image = output_barrels;
   cv_ptr->toImageMsg(outmsg);
-  g_pubs.at(camera_name).at(1).publish(outmsg);
+  g_pubs.at(camera_name).barrel.publish(outmsg);
 }
 
 /*
@@ -164,6 +199,9 @@ int main(int argc, char** argv)
   std::vector<std::string> semantic_suffixes;
   assertions::getParam(pNh, "semantic_topic_suffix", semantic_suffixes);
 
+  std::string image_base_topic;
+  assertions::getParam(pNh, "image_base_topic", image_base_topic);
+
   assertions::getParam(pNh, "output_image/width", g_output_size.width);
   assertions::getParam(pNh, "output_image/height", g_output_size.height);
 
@@ -174,7 +212,7 @@ int main(int argc, char** argv)
   assertions::getParam(pNh, "barrel_topic", barrel_topic);
 
   // insert subscribers and publishers
-  std::vector<ros::Subscriber> subs;
+  std::vector<image_transport::CameraSubscriber> subs;
   for (size_t i = 0; i < camera_names.size(); i++)
   {
     auto camera_name = camera_names[i];
@@ -184,19 +222,18 @@ int main(int argc, char** argv)
     std::string semantic_topic = prefix + line_topic;
     semantic_topic.append(suffix);
 
-    ROS_INFO_STREAM("Topic: " << semantic_topic);
-
     // subscribe to raw camera image
-    ros::Subscriber cam_sub =
-        nh.subscribe<sensor_msgs::Image>(camera_name + "/image_raw", 1, boost::bind(handleImage, _1, camera_name));
+    image_transport::ImageTransport image_transport{ nh };
+    image_transport::CameraSubscriber cam_sub = image_transport.subscribeCamera(
+        camera_name + image_base_topic, 1, boost::bind(handleImage, _1, _2, camera_name));
     subs.push_back(cam_sub);
 
     // publish line and barrel segmentation
-    ros::Publisher line_pub = nh.advertise<sensor_msgs::Image>(semantic_topic, 1);
+    image_transport::CameraPublisher cam_pub = image_transport.advertiseCamera(semantic_topic, 1);
     ros::Publisher barrel_pub = nh.advertise<sensor_msgs::Image>(camera_name + barrel_topic, 1);
-    std::vector<ros::Publisher> camera_pubs = { line_pub, barrel_pub };
+    LineBarrelPair pubs = { cam_pub, barrel_pub };
 
-    g_pubs.insert(std::make_pair(camera_name, camera_pubs));
+    g_pubs.insert(std::make_pair(camera_name, pubs));
   }
 
   ros::spin();

--- a/igvc_navigation/config/octomap.yaml
+++ b/igvc_navigation/config/octomap.yaml
@@ -77,17 +77,17 @@ segmented_free_space:
 topics:
     lidar: "/velodyne_points"
     line_segmentation:
-        left: "/cam/left/semantic_segmentation"
-        center: "/cam/center/semantic_segmentation"
-        right: "/cam/right/semantic_segmentation"
+        left: "/cam/left/segmented/image"
+        center: "/cam/center/segmented/image"
+        right: "/cam/right/segmented/image"
     projected_line_pc:
         left: "/cam/left/semantic_segmentation_cloud"
         center: "/cam/center/semantic_segmentation_cloud"
         right: "/cam/right/semantic_segmentation_cloud"
     camera_info:
-        left: "/cam/left/camera_info"
-        center: "/cam/center/camera_info"
-        right: "/cam/right/camera_info"
+        left: "/cam/left/segmented/camera_info"
+        center: "/cam/center/segmented/camera_info"
+        right: "/cam/right/segmented/camera_info"
     camera_center: "/cam/center/image_raw/compressed"
 frames:
     camera:

--- a/igvc_navigation/config/octomap_sim.yaml
+++ b/igvc_navigation/config/octomap_sim.yaml
@@ -77,17 +77,17 @@ segmented_free_space:
 topics:
     lidar: "/velodyne_points"
     line_segmentation:
-        left: "/cam/left/semantic_segmentation"
-        center: "/cam/center/semantic_segmentation"
-        right: "/cam/right/semantic_segmentation"
+        left: "/cam/left/segmented/image"
+        center: "/cam/center/segmented/image"
+        right: "/cam/right/segmented/image"
     projected_line_pc:
         left: "/cam/left/semantic_segmentation_cloud"
         center: "/cam/center/semantic_segmentation_cloud"
         right: "/cam/right/semantic_segmentation_cloud"
     camera_info:
-        left: "/cam/left/camera_info"
-        center: "/cam/center/camera_info"
-        right: "/cam/right/camera_info"
+        left: "/cam/left/segmented/camera_info"
+        center: "/cam/center/segmented/camera_info"
+        right: "/cam/right/segmented/camera_info"
     camera_center: "/cam/center/image_raw/compressed"
 frames:
     camera:

--- a/igvc_platform/launch/camera.launch
+++ b/igvc_platform/launch/camera.launch
@@ -8,9 +8,9 @@
 		    <param name="path" type="string" value="file://$(find igvc_platform)/../../../"/>
 		    <param name="video_device" type="string" value="/dev/igvc_usb_cam_center" />
 		    <param name="pixel_format" type="string" value="yuyv" />
-		    <param name="camera_frame_id" type="string" value="/usb_cam_center" />
+		    <param name="camera_frame_id" type="string" value="cam/center" />
 	 	    <param name="camera_info_url" type="string" value="file://$(find igvc_platform)/../sandbox/camera_config/usb_cam_center.yaml" />
-		    <param name="camera_name" type="string" value="usb_cam_center" />
+		    <param name="camera_name" type="string" value="cam/center/raw" />
 			<param name="framerate" value="30" />
 		</node>
 	</group>
@@ -20,9 +20,9 @@
 		    <param name="path" type="string" value="file://$(find igvc_platform)/../../../"/>
 		    <param name="video_device" type="string" value="/dev/igvc_usb_cam_right" />
 		    <param name="pixel_format" type="string" value="yuyv" />
-		    <param name="camera_frame_id" type="string" value="/usb_cam_right" />
+		    <param name="camera_frame_id" type="string" value="cam/right" />
 	 	    <param name="camera_info_url" type="string" value="file://$(find igvc_platform)/../sandbox/camera_config/usb_cam_right.yaml" />
-		    <param name="camera_name" type="string" value="usb_cam_right" />
+		    <param name="camera_name" type="string" value="cam/center/raw" />
 			<param name="framerate" value="30" />
 		</node>
 	</group>
@@ -32,9 +32,9 @@
 		    <param name="path" type="string" value="file://$(find igvc_platform)/../../../"/>
 		    <param name="video_device" type="string" value="/dev/igvc_usb_cam_left" />
 		    <param name="pixel_format" type="string" value="yuyv" />
-		    <param name="camera_frame_id" type="string" value="/usb_cam_left" />
+		    <param name="camera_frame_id" type="string" value="cam/left" />
 	 	    <param name="camera_info_url" type="string" value="file://$(find igvc_platform)/../sandbox/camera_config/usb_cam_left.yaml" />
-		    <param name="camera_name" type="string" value="usb_cam_left" />
+		    <param name="camera_name" type="string" value="cam/center/raw" />
 			<param name="framerate" value="30" />
 		</node>
 	</group>


### PR DESCRIPTION
# Description

Even though #503 was merged which closed #450, I realized that the camera frame and topic names were still kind of not that nice. What I mean by this is that the `sensor_msgs::CameraInfo` and `sensor_msgs::Image` topics for a camera are like `cam/center/CameraInfo` and `cam/center/image_raw`.

However, for the output of the neural network, which scales the image (and thus needs a different `sensor_msgs::CameraInfo`, the the `sensor_msgs::Image` topic is `cam/center/semantic_segmentation`. The problem thus comes with where the `sensor_msgs::CameraInfo` for the segmented image should go. According to the `image_transport::CameraSubscriber`, and `image_transport::ImageTransport`, the topic for the `sensor_msgs::CameraInfo` should be in the same namespace as the `sensor_msgs::Image` topic, which makes things quite awkward for the segmented image as that would result in the same topic as the raw image.

In order to solve this problem, and also make better use of namespaces, this PR does the following: 
- Rename the "raw" camera image topics to `cam/center/raw/image`, with the `CameraInfo` topic being `cam/center/raw/camera_info`
- Rename the segmented image topic to `cam/center/segmented/image`, with the corresponding `CameraInfo` topic being `cam/center/segmented/camera_info`
- Add a `scaleCameraInfo` method to `sim_color_detector` so that it correctly publishes both the 400x400 segmented image, as well as the modified `CameraInfo` of the segmented image
- Change the _old mapper_ to use the new camera topics by updating the topic names in `octomap_sim.yaml` and `octomap.yaml`
- Update the topics in `camera.launch`

Fixes #450 again.

Note: Neither `cnn.py` nor `vision.launch` was updated. This is because I think that both files need to be refactored (multiple responsibilities, make the file cleaner etc.), and so I will make a new issue for that specifically.

# Testing steps (If relevant)
## Mapper still works with the updated frames
1. Launch simulation. `roslaunch igvc_gazebo qualification.launch`
2. Launch old mapper: `roslaunch igvc_navigation navigation_simulation.launch`
3. Open up the `mapper/debug/map_debug_pcl` topic on rviz

Expectation: Same behavior as before. Mapper is able to subscribe to segmented images and lines are visible on the map.

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
