### PR TITLE
Changed ensure_submodules to check for .git folder inside submodule

### DIFF
--- a/cmake/ensure_submodules.cmake
+++ b/cmake/ensure_submodules.cmake
@@ -29,9 +29,9 @@ if(NOT EXISTS ${GIT_REPO_DIR}/external)
 endif()
 
 foreach(EXTERNAL_PACKAGE ${EXTERNAL_PACKAGES})
-    if(NOT EXISTS ${GIT_REPO_DIR}/external/${EXTERNAL_PACKAGE})
+    if(NOT EXISTS ${GIT_REPO_DIR}/external/${EXTERNAL_PACKAGE}/.git)
         set(EXTERNAL_PACKAGES_FOUND False)
-        message(WARNING "Couldn't find external package external/${EXTERNAL_PACKAGE}...")
+        message(WARNING "Couldn't find .git folder in external package external/${EXTERNAL_PACKAGE}/.git ...")
     endif()
 endforeach()
 


### PR DESCRIPTION
# Description

I thought we fixed #490 with #491, but turns out the submodule folder _does_ exist, it's just that there's nothing inside it.

This PR does the following:
- Change the check to check the `.git` folder inside the submodule instead of the folder itself

Fixes #516.

# Testing steps (If relevant)
## Check works for if the submodule folder exists but is empty
1. Delete `igvc-software` folder
2. Clone it without `--recursive`
3. Run `catkin_make`

Expectation: It should scream at you telling you to run `catkin_make` again.

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
