### PR TITLE
Force color if ninja generator is used

### DIFF
--- a/igvc.cmake
+++ b/igvc.cmake
@@ -5,3 +5,11 @@ add_compile_options(-W -Wall -Wextra)
 set(GIT_REPO_DIR ${CMAKE_CURRENT_LIST_DIR})
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/ensure_submodules.cmake)
 
+# Add color for ninja generator
+if (CMAKE_GENERATOR STREQUAL "Ninja" AND
+((CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9) OR
+(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.5)))
+    # Force colored warnings in Ninja's output, if the compiler has -fdiagnostics-color support.
+    # Rationale in https://github.com/ninja-build/ninja/issues/814
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")
+endif()


### PR DESCRIPTION
# Description
If the ninja generator is used, then no color is output.

This PR does the following:
- Add a check in cmake for the ninja generator to force color output.

Steals the solution for the problem from [KDE](https://phabricator.kde.org/D3733)

Fixes #527.

# Testing steps (If relevant)
## It compiles properly
1. `catkin_make` (so using make)

Expectation: It compiles

## It compiles properly using ninja
1. `catkin_make --use-ninja` (`build` needs to be deleted first)

Expectation: It compiles

## Color is shown using ninja
1. Delete something somewhere so a syntax error occurs
2. `catkin_make --use-ninja`

Expectation: Red text is shown for the errors.

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
