### PR TITLE
Added check for if no cpp files were modified

### DIFF
--- a/.circleci/utils/tidy.sh
+++ b/.circleci/utils/tidy.sh
@@ -87,6 +87,11 @@ done < <(git diff-tree --no-commit-id --diff-filter=d --name-only -r "$base" HEA
 # =====================
 modified_filepaths=($(echo "${modified_filepaths[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
 
+if [ ${#modified_filepaths[@]} -eq 0 ]; then
+  echo "No changed cpp files!"
+  exit 0
+fi
+
 # =========================
 # | Run with GNU parallel |
 # =========================


### PR DESCRIPTION
# Description
The script for clang-tidy doesn't check for the edge case if there are no cpp files that are changed.

This PR does the following:
- Fixes that

Fixes #558 

# Testing steps (If relevant)
## CI doesn't break
1. Check the CI result

Expectation: Since this change also contains no cpp files changes, the clang-tidy step for CI should pass

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
