### PR TITLE
Fixed nondeterministic bug in joystick test by creating helper class

### DIFF
--- a/igvc_platform/src/tests/test_joystick_driver.cpp
+++ b/igvc_platform/src/tests/test_joystick_driver.cpp
@@ -32,8 +32,8 @@ public:
 
   void init(const std::string& topic, int queue_size = 1);
 
-  [[nodiscard]] bool waitForPublisher(const ros::Duration& timeout = ros::Duration{ 0 }) const;
-  bool spinUntilMessages(const ros::Duration& timeout = ros::Duration{ 0 }, int num_messages = 1);
+  [[nodiscard]] bool waitForPublisher(const ros::Duration& timeout = ros::Duration{ 5 }) const;
+  bool spinUntilMessages(const ros::Duration& timeout = ros::Duration{ 5 }, int num_messages = 1);
   [[nodiscard]] bool hasMessage() const;
   [[nodiscard]] const MessageType& front() const;
   [[nodiscard]] const std::vector<MessageType>& messages() const;
@@ -139,6 +139,22 @@ public:
   }
 
 protected:
+  [[nodiscard]] bool waitForSubscriber() const
+  {
+    const double timeout = 5.0;
+    const double sleep_time = 1.0;
+    ros::Time end = ros::Time::now() + ros::Duration(timeout);
+    while (mock_joy_pub.getNumSubscribers() == 0)
+    {
+      ros::Duration(sleep_time).sleep();
+      if (ros::Time::now() > end)
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+
   ros::NodeHandle handle;
   ros::Publisher mock_joy_pub;
 };
@@ -156,6 +172,8 @@ TEST_F(TestJoystickDriver, FullForward)
 {
   MockMotorSubscriber mock_sub("/motors");
   ASSERT_TRUE(mock_sub.waitForPublisher());
+  ASSERT_TRUE(waitForSubscriber());
+
   const float full_speed = 1.0;
   mock_joy_pub.publish(createJoyMsg(full_speed, full_speed));
 
@@ -172,6 +190,7 @@ TEST_F(TestJoystickDriver, FullReverse)
 {
   MockMotorSubscriber mock_sub("/motors");
   ASSERT_TRUE(mock_sub.waitForPublisher());
+  ASSERT_TRUE(waitForSubscriber());
   const float full_speed = 1.0;
   mock_joy_pub.publish(createJoyMsg(-full_speed, -full_speed));
 
@@ -188,6 +207,7 @@ TEST_F(TestJoystickDriver, SpinRight)
 {
   MockMotorSubscriber mock_sub("/motors");
   ASSERT_TRUE(mock_sub.waitForPublisher());
+  ASSERT_TRUE(waitForSubscriber());
   const float full_speed = 1.0;
   mock_joy_pub.publish(createJoyMsg(full_speed, -full_speed));
 
@@ -204,6 +224,7 @@ TEST_F(TestJoystickDriver, SpinLeft)
 {
   MockMotorSubscriber mock_sub("/motors");
   ASSERT_TRUE(mock_sub.waitForPublisher());
+  ASSERT_TRUE(waitForSubscriber());
   const float full_speed = 1.0;
   mock_joy_pub.publish(createJoyMsg(-full_speed, full_speed));
 
@@ -220,6 +241,7 @@ TEST_F(TestJoystickDriver, HalfSpeedForward)
 {
   MockMotorSubscriber mock_sub("/motors");
   ASSERT_TRUE(mock_sub.waitForPublisher());
+  ASSERT_TRUE(waitForSubscriber());
   const float half_speed = 0.5;
   mock_joy_pub.publish(createJoyMsg(half_speed, half_speed));
 

--- a/igvc_platform/src/tests/test_joystick_driver.cpp
+++ b/igvc_platform/src/tests/test_joystick_driver.cpp
@@ -139,8 +139,7 @@ public:
   }
 
 protected:
-  [[nodiscard]] bool waitForSubscriber() const
-  {
+  [[nodiscard]] bool waitForSubscriber() const {
     const double timeout = 5.0;
     const double sleep_time = 1.0;
     ros::Time end = ros::Time::now() + ros::Duration(timeout);

--- a/igvc_platform/src/tests/test_joystick_driver.cpp
+++ b/igvc_platform/src/tests/test_joystick_driver.cpp
@@ -86,7 +86,8 @@ bool MockMotorSubscriber::waitForPublisher(const ros::Duration& timeout) const
   ros::Time end = ros::Time::now() + timeout;
   while (sub_.getNumPublishers() == 0)
   {
-    ros::WallDuration(0.1).sleep();
+    const double sleep_duration = 0.1;
+    ros::WallDuration{sleep_duration}.sleep();
     if (!timeout.isZero() && ros::Time::now() >= end)
     {
       return false;
@@ -120,7 +121,8 @@ bool MockMotorSubscriber::spinUntilMessages(const ros::Duration& timeout, int nu
   ros::Time end = ros::Time::now() + timeout;
   while (static_cast<int>(message_buffer_.size()) < num_messages)
   {
-    callback_queue_.callAvailable(ros::WallDuration{ 0.1 });
+    const double sleep_duration = 0.1;
+    callback_queue_.callAvailable(ros::WallDuration{ sleep_duration});
     if (!timeout.isZero() && ros::Time::now() >= end)
     {
       return false;

--- a/igvc_platform/src/tests/test_joystick_driver.cpp
+++ b/igvc_platform/src/tests/test_joystick_driver.cpp
@@ -4,119 +4,230 @@
 
 #include <gtest/gtest.h>
 #include <igvc_msgs/velocity_pair.h>
+#include <ros/callback_queue.h>
 #include <ros/ros.h>
 #include <sensor_msgs/Joy.h>
+
+// TODO: Make this templated
+
+/**
+ * \brief A wrapper class around a Subscriber for testing.
+ *
+ * A MockMotorSubscriber contains helper methods such as blocking until there is a publisher
+ * and spinning until a message arrives.
+ *
+ * A user provided callback function can be called to perform additional testing logic on a callback
+ */
+class MockMotorSubscriber
+{
+public:
+  using MessageType = igvc_msgs::velocity_pair;
+  using CBFunctionType = std::function<void(const MessageType&)>;
+
+  MockMotorSubscriber(const std::string& topic, CBFunctionType cb_function, int queue_size = 1);
+  MockMotorSubscriber(const std::string& topic, int queue_size = 1);
+  ~MockMotorSubscriber();
+  MockMotorSubscriber(const MockMotorSubscriber&) = delete;
+  MockMotorSubscriber& operator=(const MockMotorSubscriber&) = delete;
+
+  void init(const std::string& topic, int queue_size = 1);
+
+  [[nodiscard]] bool waitForPublisher(const ros::Duration& timeout = ros::Duration{ 0 }) const;
+  bool spinUntilMessages(const ros::Duration& timeout = ros::Duration{ 0 }, int num_messages = 1);
+  [[nodiscard]] bool hasMessage() const;
+  [[nodiscard]] const MessageType& front() const;
+  [[nodiscard]] const std::vector<MessageType>& messages() const;
+
+private:
+  void callback(const MessageType::ConstPtr& message);
+  std::optional<CBFunctionType> cb_function_;
+  ros::Subscriber sub_;
+  ros::CallbackQueue callback_queue_;
+
+  std::vector<MessageType> message_buffer_;
+};
+
+MockMotorSubscriber::MockMotorSubscriber(const std::string& topic, CBFunctionType cb_function, int queue_size)
+  : cb_function_{ std::move(cb_function) }
+{
+  init(topic, queue_size);
+}
+
+MockMotorSubscriber::MockMotorSubscriber(const std::string& topic, int queue_size)
+{
+  init(topic, queue_size);
+}
+
+MockMotorSubscriber::~MockMotorSubscriber()
+{
+  sub_.shutdown();
+}
+
+void MockMotorSubscriber::init(const std::string& topic, int queue_size)
+{
+  ros::NodeHandle nh;
+  ros::SubscribeOptions ops;
+  ops.template init<igvc_msgs::velocity_pair>(topic, queue_size, boost::bind(&MockMotorSubscriber::callback, this, _1));
+  ops.callback_queue = &callback_queue_;
+  sub_ = nh.subscribe(ops);
+}
+
+void MockMotorSubscriber::callback(const MessageType::ConstPtr& message)
+{
+  message_buffer_.emplace_back(*message);
+  if (cb_function_)
+  {
+    cb_function_.value()(*message);
+  }
+}
+
+bool MockMotorSubscriber::waitForPublisher(const ros::Duration& timeout) const
+{
+  ros::Time end = ros::Time::now() + timeout;
+  while (sub_.getNumPublishers() == 0)
+  {
+    ros::WallDuration(0.1).sleep();
+    if (!timeout.isZero() && ros::Time::now() >= end)
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool MockMotorSubscriber::hasMessage() const
+{
+  return !message_buffer_.empty();
+}
+
+const MockMotorSubscriber::MessageType& MockMotorSubscriber::front() const
+{
+  return message_buffer_.front();
+}
+
+const std::vector<MockMotorSubscriber::MessageType>& MockMotorSubscriber::messages() const
+{
+  return message_buffer_;
+}
+
+bool MockMotorSubscriber::spinUntilMessages(const ros::Duration& timeout, int num_messages)
+{
+  if (sub_.getNumPublishers() == 0)
+  {
+    return false;
+  }
+
+  ros::Time end = ros::Time::now() + timeout;
+  while (static_cast<int>(message_buffer_.size()) < num_messages)
+  {
+    callback_queue_.callAvailable(ros::WallDuration{ 0.1 });
+    if (!timeout.isZero() && ros::Time::now() >= end)
+    {
+      return false;
+    }
+  }
+  return true;
+}
 
 class TestJoystickDriver : public testing::Test
 {
 public:
-  TestJoystickDriver()
-    : handle()
-    , mock_joy_pub(handle.advertise<sensor_msgs::Joy>("/joy", 1))
-    , motor_sub(handle.subscribe("/motors", 1, &TestJoystickDriver::motorsCallback, this))
-  {
-  }
-
-  void motorsCallback(const igvc_msgs::velocity_pair::ConstPtr& msg)
+  TestJoystickDriver() : mock_joy_pub(handle.advertise<sensor_msgs::Joy>("/joy", 1))
   {
   }
 
 protected:
-  virtual void SetUp()
-  {
-    while (!IsNodeReady())
-    {
-      ros::spinOnce();
-    }
-  }
-
-  virtual void TearDown()
-  {
-  }
-
-  bool IsNodeReady()
-  {
-    return (mock_joy_pub.getNumSubscribers() > 0) && (motor_sub.getNumPublishers() > 0);
-  }
-
   ros::NodeHandle handle;
   ros::Publisher mock_joy_pub;
-  ros::Subscriber motor_sub;
 };
+
+sensor_msgs::Joy createJoyMsg(float left, float right)
+{
+  sensor_msgs::Joy joy_msg;
+  joy_msg.axes = { 0, left, 0, 0, right };
+  joy_msg.buttons = { 0, 0, 0, 0 };
+
+  return joy_msg;
+}
 
 TEST_F(TestJoystickDriver, FullForward)
 {
-  sensor_msgs::Joy joy_msg;
-  joy_msg.axes = { 0, 1.0, 0, 0, 1.0 };
-  joy_msg.buttons = { 0, 0, 0, 0 };
-  mock_joy_pub.publish(joy_msg);
+  MockMotorSubscriber mock_sub("/motors");
+  ASSERT_TRUE(mock_sub.waitForPublisher());
+  const float full_speed = 1.0;
+  mock_joy_pub.publish(createJoyMsg(full_speed, full_speed));
 
-  const igvc_msgs::velocity_pair::ConstPtr response =
-      ros::topic::waitForMessage<igvc_msgs::velocity_pair>(motor_sub.getTopic(), ros::Duration(10));
+  ASSERT_TRUE(mock_sub.spinUntilMessages());
 
-  EXPECT_TRUE(response.get() != nullptr);
-  EXPECT_EQ(response->left_velocity, 1.0);
-  EXPECT_EQ(response->right_velocity, 1.0);
+  ASSERT_EQ(mock_sub.messages().size(), 1LU);
+  const igvc_msgs::velocity_pair& response = mock_sub.front();
+
+  EXPECT_EQ(response.left_velocity, full_speed);
+  EXPECT_EQ(response.right_velocity, full_speed);
 }
 
 TEST_F(TestJoystickDriver, FullReverse)
 {
-  sensor_msgs::Joy joy_msg;
-  joy_msg.axes = { 0, -1.0, 0, 0, -1.0 };
-  joy_msg.buttons = { 0, 0, 0, 0 };
-  mock_joy_pub.publish(joy_msg);
+  MockMotorSubscriber mock_sub("/motors");
+  ASSERT_TRUE(mock_sub.waitForPublisher());
+  const float full_speed = 1.0;
+  mock_joy_pub.publish(createJoyMsg(-full_speed, -full_speed));
 
-  const igvc_msgs::velocity_pair::ConstPtr response =
-      ros::topic::waitForMessage<igvc_msgs::velocity_pair>(motor_sub.getTopic(), ros::Duration(10));
+  ASSERT_TRUE(mock_sub.spinUntilMessages());
 
-  EXPECT_TRUE(response.get() != nullptr);
-  EXPECT_EQ(response->left_velocity, -1.0);
-  EXPECT_EQ(response->right_velocity, -1.0);
+  ASSERT_EQ(mock_sub.messages().size(), 1LU);
+  const igvc_msgs::velocity_pair& response = mock_sub.front();
+
+  EXPECT_EQ(response.left_velocity, -full_speed);
+  EXPECT_EQ(response.right_velocity, -full_speed);
 }
 
 TEST_F(TestJoystickDriver, SpinRight)
 {
-  sensor_msgs::Joy joy_msg;
-  joy_msg.axes = { 0, 1.0, 0, 0, -1.0 };
-  joy_msg.buttons = { 0, 0, 0, 0 };
-  mock_joy_pub.publish(joy_msg);
+  MockMotorSubscriber mock_sub("/motors");
+  ASSERT_TRUE(mock_sub.waitForPublisher());
+  const float full_speed = 1.0;
+  mock_joy_pub.publish(createJoyMsg(full_speed, -full_speed));
 
-  const igvc_msgs::velocity_pair::ConstPtr response =
-      ros::topic::waitForMessage<igvc_msgs::velocity_pair>(motor_sub.getTopic(), ros::Duration(10));
+  ASSERT_TRUE(mock_sub.spinUntilMessages());
 
-  EXPECT_TRUE(response.get() != nullptr);
-  EXPECT_EQ(response->left_velocity, 1.0);
-  EXPECT_EQ(response->right_velocity, -1.0);
+  ASSERT_EQ(mock_sub.messages().size(), 1LU);
+  const igvc_msgs::velocity_pair& response = mock_sub.front();
+
+  EXPECT_EQ(response.left_velocity, full_speed);
+  EXPECT_EQ(response.right_velocity, -full_speed);
 }
 
 TEST_F(TestJoystickDriver, SpinLeft)
 {
-  sensor_msgs::Joy joy_msg;
-  joy_msg.axes = { 0, -1.0, 0, 0, 1.0 };
-  joy_msg.buttons = { 0, 0, 0, 0 };
-  mock_joy_pub.publish(joy_msg);
+  MockMotorSubscriber mock_sub("/motors");
+  ASSERT_TRUE(mock_sub.waitForPublisher());
+  const float full_speed = 1.0;
+  mock_joy_pub.publish(createJoyMsg(-full_speed, full_speed));
 
-  const igvc_msgs::velocity_pair::ConstPtr response =
-      ros::topic::waitForMessage<igvc_msgs::velocity_pair>(motor_sub.getTopic(), ros::Duration(10));
+  ASSERT_TRUE(mock_sub.spinUntilMessages());
 
-  EXPECT_TRUE(response.get() != nullptr);
-  EXPECT_EQ(response->left_velocity, -1.0);
-  EXPECT_EQ(response->right_velocity, 1.0);
+  ASSERT_EQ(mock_sub.messages().size(), 1LU);
+  const igvc_msgs::velocity_pair& response = mock_sub.front();
+
+  EXPECT_EQ(response.left_velocity, -full_speed);
+  EXPECT_EQ(response.right_velocity, full_speed);
 }
 
 TEST_F(TestJoystickDriver, HalfSpeedForward)
 {
-  sensor_msgs::Joy joy_msg;
-  joy_msg.axes = { 0, 0.5, 0, 0, 0.5 };
-  joy_msg.buttons = { 0, 0, 0, 0 };
-  mock_joy_pub.publish(joy_msg);
+  MockMotorSubscriber mock_sub("/motors");
+  ASSERT_TRUE(mock_sub.waitForPublisher());
+  const float half_speed = 0.5;
+  mock_joy_pub.publish(createJoyMsg(half_speed, half_speed));
 
-  const igvc_msgs::velocity_pair::ConstPtr response =
-      ros::topic::waitForMessage<igvc_msgs::velocity_pair>(motor_sub.getTopic(), ros::Duration(10));
+  ASSERT_TRUE(mock_sub.spinUntilMessages());
 
-  EXPECT_TRUE(response.get() != nullptr);
-  EXPECT_EQ(response->left_velocity, 0.5);
-  EXPECT_EQ(response->right_velocity, 0.5);
+  ASSERT_EQ(mock_sub.messages().size(), 1LU);
+  const igvc_msgs::velocity_pair& response = mock_sub.front();
+
+  EXPECT_EQ(response.left_velocity, half_speed);
+  EXPECT_EQ(response.right_velocity, half_speed);
 }
 
 int main(int argc, char** argv)
@@ -124,10 +235,7 @@ int main(int argc, char** argv)
   ros::init(argc, argv, "test_joystick_driver");
   testing::InitGoogleTest(&argc, argv);
 
-  ros::AsyncSpinner spinner(1);
-  spinner.start();
   int ret = RUN_ALL_TESTS();
-  spinner.stop();
   ros::shutdown();
   return ret;
 }

--- a/igvc_platform/src/tests/test_joystick_driver.cpp
+++ b/igvc_platform/src/tests/test_joystick_driver.cpp
@@ -87,7 +87,7 @@ bool MockMotorSubscriber::waitForPublisher(const ros::Duration& timeout) const
   while (sub_.getNumPublishers() == 0)
   {
     const double sleep_duration = 0.1;
-    ros::WallDuration{sleep_duration}.sleep();
+    ros::WallDuration{ sleep_duration }.sleep();
     if (!timeout.isZero() && ros::Time::now() >= end)
     {
       return false;
@@ -122,7 +122,7 @@ bool MockMotorSubscriber::spinUntilMessages(const ros::Duration& timeout, int nu
   while (static_cast<int>(message_buffer_.size()) < num_messages)
   {
     const double sleep_duration = 0.1;
-    callback_queue_.callAvailable(ros::WallDuration{ sleep_duration});
+    callback_queue_.callAvailable(ros::WallDuration{ sleep_duration });
     if (!timeout.isZero() && ros::Time::now() >= end)
     {
       return false;


### PR DESCRIPTION
# Description
We've had a non-deterministic joystick test bug for a long time.

This PR does the following:
- Fixes the damn thing.

Fixes #575 

# Testing steps (If relevant)
## Run tests
1. Run `catkin_make run_tests_igvc_platform`
2. Repeat 1 as many times as you want

Expectation: It doesn't fail

To be honest, if there still was a race condition, you would probably need to run it like a few thousand times in order for it to show itself. I think the current code doesn't have a race condition though, so until it shows itself again ¯\_(ツ)_/¯

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
