### PR TITLE
Created correct footprint based on CAD measurements

### DIFF
--- a/igvc_navigation/config/global_costmap_params.yaml
+++ b/igvc_navigation/config/global_costmap_params.yaml
@@ -5,7 +5,7 @@ global_costmap:
         - {name: static_map,       type: "costmap_2d::StaticLayer"}
         - {name: inflation_layer,       type: "costmap_2d::InflationLayer"}
     publish_frequency: 5.0
-    footprint: [[0.4,0.4],[-0.4,0.4],[-0.4,-0.4],[0.4,-0.4]]
+    footprint: [[-0.24,0.32],[0.72,0.32],[0.72,-0.32],[-0.24,-0.32]]
     width: 200
     height: 200
     origin_x: -100

--- a/igvc_navigation/config/local_costmap_params.yaml
+++ b/igvc_navigation/config/local_costmap_params.yaml
@@ -5,7 +5,7 @@ local_costmap:
         - {name: lidar_layer,     type: "lidar_layer::LidarLayer"}
         - {name: line_layer,     type: "line_layer::LineLayer"}
     publish_frequency: 5.0
-    footprint: [[0.4,0.4],[-0.4,0.4],[-0.4,-0.4],[0.4,-0.4]]
+    footprint: [[-0.24,0.32],[0.72,0.32],[0.72,-0.32],[-0.24,-0.32]]
     width: 200
     height: 200
     origin_x: -100


### PR DESCRIPTION
# Description
Our current footprints are temporary and thus incorrect.

This PR does the following:
- Changes the footprint to a rectangular shape that is correct according to CAD measurements.

Fixes #537 

# Testing steps (If relevant)
## The footprint appears correct in rviz
1. Open up simulation. `roslaunch igvc_gazebo qualification.launch`
2. Run the navigation stack. `roslaunch igvc_navigation navigation_simulation.launch`
3. Open up rviz and add the `Polygon` display for topic `/move_base_flex/local_costmap/footprint`

Expectation: There should be a rectangle that has the same dimensions as the pdf in the issue.

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
