### PR TITLE
Ignore generated files

### DIFF
--- a/.circleci/utils/tidy.sh
+++ b/.circleci/utils/tidy.sh
@@ -3,6 +3,9 @@
 # some settings
 tidied_files_path=".circleci/utils/tidied_files.txt"
 
+# Ignore pb.c / pb.h generated files
+IGNORE_REGEX="pb\.[ch]"
+
 
 # For pretty printing
 if test -t 1; then
@@ -72,7 +75,7 @@ do
   absolute_filepath=$(realpath "$line")
 
   # Append the absolute filepath.
-  if echo "$absolute_filepath" | grep -q -E '(\.cpp)|(\.h)'; then
+  if echo "$absolute_filepath" | grep -q -E '(\.cpp)|(\.h)' | grep -v -E "${IGNORE_REGEX}" ; then
     echo "$absolute_filepath"
     modified_filepaths+=("$absolute_filepath")
   fi


### PR DESCRIPTION
# Description
After changing the protobuf files in #583, CI was failing because the generated files weren't weren't passing the `clang-tidy` lint.

This PR does the following:
- Excludes generated files (for now implemented by a negative regex) from `clang-tidy`

Fixes #584

# Testing steps (If relevant)
## Test `clang-tidy`
1. Make some change to  [igvc.pb.h](https://github.com/RoboJackets/igvc-software/blob/master/igvc_platform/include/igvc_platform/nanopb/protos/igvc.pb.h)
2. Run `clang-tidy`: `.circleci/utils/tidy.sh`

Expectation: Even though `igvc.pb.h` was modified, because of the negative regex it says `No changed cpp files!`

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
