### PR TITLE
Add max distance for line_layer

### DIFF
--- a/igvc_navigation/config/global_costmap_params.yaml
+++ b/igvc_navigation/config/global_costmap_params.yaml
@@ -10,7 +10,7 @@ global_costmap:
     height: 200
     origin_x: -100
     origin_y: -100
-    track_unknown_space: true
+    track_unknown_space: false
     unknown_cost_value: 30
     rolling_window: false
     resolution: 0.1

--- a/igvc_navigation/config/local_costmap_params.yaml
+++ b/igvc_navigation/config/local_costmap_params.yaml
@@ -10,7 +10,7 @@ local_costmap:
     height: 200
     origin_x: -100
     origin_y: -100
-    track_unknown_space: true
+    track_unknown_space: false
     unknown_cost_value: 30
     static_map: false
     rolling_window: false
@@ -53,6 +53,7 @@ line_layer:
             raw_image: "/image"
             segmented_image_ns: "/segmented"
             segmented_image: "/image"
+        max_distance: 10
         probabilities:
             miss: 0.7
             hit: 0.7
@@ -68,6 +69,7 @@ line_layer:
             raw_image: "/image"
             segmented_image_ns: "/segmented"
             segmented_image: "/image"
+        max_distance: 10
         probabilities:
             miss: 0.7
             hit: 0.7
@@ -83,6 +85,7 @@ line_layer:
             raw_image: "/image"
             segmented_image_ns: "/segmented"
             segmented_image: "/image"
+        max_distance: 10
         probabilities:
             miss: 0.7
             hit: 0.7

--- a/igvc_navigation/src/mapper/camera_config.cpp
+++ b/igvc_navigation/src/mapper/camera_config.cpp
@@ -13,6 +13,10 @@ CameraConfig::CameraConfig(const ros::NodeHandle& parent_nh, const std::string& 
   assertions::getParam(nh, "topics/segmented_image_ns", topics.segmented_image_ns);
   assertions::getParam(nh, "topics/segmented_image", topics.segmented_image);
 
+  double max_distance;
+  assertions::getParam(nh, "max_distance", max_distance);
+  max_squared_distance = max_distance * max_distance;
+
   assertions::getParam(nh, "probabilities/miss", miss);
   miss = probability_utils::toLogOdds(1.0 - miss);  // It's a miss, so 1 - hit
   assertions::getParam(nh, "probabilities/hit", hit);

--- a/igvc_navigation/src/mapper/camera_config.h
+++ b/igvc_navigation/src/mapper/camera_config.h
@@ -18,6 +18,7 @@ public:
   double miss;
   double hit_exponential_coeff;
   double hit;
+  double max_squared_distance;
 
   struct
   {

--- a/igvc_navigation/src/mapper/line_layer.cpp
+++ b/igvc_navigation/src/mapper/line_layer.cpp
@@ -374,8 +374,12 @@ void LineLayer::insertProjectionsIntoMap(const geometry_msgs::TransformStamped &
         map_.getPosition(map_index, position);
         const auto dx = position[0] - camera_x;
         const auto dy = position[1] - camera_y;
-        double distance = dx * dx + dy * dy;
-        markHit(map_index, distance, config);
+        double squared_distance = dx * dx + dy * dy;
+
+        if (squared_distance < config.max_squared_distance)
+        {
+          markHit(map_index, squared_distance, config);
+        }
       }
     }
   }
@@ -396,9 +400,13 @@ void LineLayer::insertProjectionsIntoMap(const geometry_msgs::TransformStamped &
         map_.getPosition(map_index, position);
         const auto dx = position[0] - camera_x;
         const auto dy = position[1] - camera_y;
-        const double distance = dx * dx + dy * dy;
+        const double squared_distance = dx * dx + dy * dy;
         const double angle = angles::normalize_angle(camera_heading - std::atan2(dy, dx));
-        markEmpty(map_index, distance, angle, config);
+
+        if (squared_distance < config.max_squared_distance)
+        {
+          markEmpty(map_index, squared_distance, angle, config);
+        }
       }
     }
   }


### PR DESCRIPTION
# Description
Our projections and our line segmentation are bad at longer distances, resulting in us "forgetting lines" at longer distance due to free space clearing.

This PR does the following:
- Adds a maximum distance to the line_layer
- Also sets "track_unknown" to false (but I don't want to make a new PR for this)

Fixes #590 

# Testing steps (If relevant)
## Maximum distance works
1. First, set `miss_exponential_coeff`, `miss_angle_exponential_coeff`, and `hit_exponential_coeff` to `0`, so that we don't get exponential decay due to distance for probabilities
2. Open up simulation
3. Open up rviz
4. Drive further than 10 meters from a line (Check rviz)
5. Open up our navigation stack. `roslaunch igvc_navigation navigation_simulation.launch`
6. Slowly drive forwards using a joystick or `rostopic pub`

Expectation: All lines that are within 10m are plotted, anything outside is ignored

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
