### PR TITLE
Small fix for ground segmentation

### DIFF
--- a/igvc_perception/config/pointcloud_filter.yaml
+++ b/igvc_perception/config/pointcloud_filter.yaml
@@ -23,7 +23,7 @@ pointcloud_filter:
         nonground_topic: "/nonground"
         num_segments: 270
         error_t: .015
-        slope_t: .4
+        slope_t: .3
         intercept_z_t: 100
         dist_t: .1
         debug_viz: true

--- a/igvc_perception/src/pointcloud_filter/fast_segment_filter/fast_segment_filter.cpp
+++ b/igvc_perception/src/pointcloud_filter/fast_segment_filter/fast_segment_filter.cpp
@@ -214,7 +214,7 @@ double FastSegmentFilter::getDistanceBetweenPoints(const velodyne_pointcloud::Po
 
 bool FastSegmentFilter::evaluateIsGround(Line &l)
 {
-  const auto above_intercept = [&](const Prototype &pt) { return pt.point_.z > config_.dist_t; };
+  const auto above_intercept = [&](const Prototype &pt) { return pt.point_.z < config_.dist_t; };
   bool all_below = std::all_of(l.model_points_.begin(), l.model_points_.end(), above_intercept);
   if (all_below)
   {

--- a/igvc_perception/src/pointcloud_filter/fast_segment_filter/fast_segment_filter.cpp
+++ b/igvc_perception/src/pointcloud_filter/fast_segment_filter/fast_segment_filter.cpp
@@ -214,8 +214,8 @@ double FastSegmentFilter::getDistanceBetweenPoints(const velodyne_pointcloud::Po
 
 bool FastSegmentFilter::evaluateIsGround(Line &l)
 {
-  const auto above_intercept = [&](const Prototype &pt) { return pt.point_.z < config_.dist_t; };
-  bool all_below = std::all_of(l.model_points_.begin(), l.model_points_.end(), above_intercept);
+  const auto below_intercept = [&](const Prototype &pt) { return pt.point_.z < config_.dist_t; };
+  bool all_below = std::all_of(l.model_points_.begin(), l.model_points_.end(), below_intercept);
   if (all_below)
   {
     return true;


### PR DESCRIPTION
# Description

Fix for ground segmentation from #610 

This PR does the following:
- Changes one line in the `FastSegmentFilter::evaluteIsGround` function to properly check if all the points in a line are below a z threshold.

# Testing steps (If relevant)
1. Run `roslaunch igvc_gazebo autonav.launch`
2. Run `roslaunch igvc_perception pointcloud_filter.launch`
3. Open `rviz`

Expectation: You should see nonground points like barrels in the `/nonground` topic and ground points in the `/ground` topic.


# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 