### PR TITLE
fix for issue 637 cmath inclusion

### DIFF
--- a/igvc_navigation/include/mapper/probability_utils.h
+++ b/igvc_navigation/include/mapper/probability_utils.h
@@ -1,6 +1,8 @@
 #ifndef SRC_PROBABILITY_UTILS_H
 #define SRC_PROBABILITY_UTILS_H
 
+#include <cmath>
+
 namespace probability_utils
 {
 template <typename T>


### PR DESCRIPTION
# Description

This pull request is for fixing issue 637 where a non-inclusion of cmath in a file that calls std::log and std::exp is causing compile error when running catkin_make.

This PR does the following:
- just adding #include <cmath>

Fixes #637 

Expectation: catkin_make should pass without throwing error

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
