### PR TITLE
Change mesh waypoints handling to new format

### DIFF
--- a/igvc_gazebo/launch/autonav_mesh.launch
+++ b/igvc_gazebo/launch/autonav_mesh.launch
@@ -18,7 +18,8 @@
 
     <include file="$(find igvc_gazebo)/launch/simulation.launch">
         <arg name="world_name" value="$(find igvc_description)/urdf/worlds/autonav_mesh.world"/>
-        <arg name="waypoints" value="$(find igvc_gazebo)/config/waypoints_autonav_$(arg track).csv" />
+        <arg name="waypoint_folder_path" value="$(find igvc_gazebo)/config"/>
+        <arg name="waypoint_file_name" value="waypoints_autonav_$(arg track).csv"/>
 
         <arg name="x" value="$(arg x)"/>
         <arg name="y" value="$(arg y)"/>


### PR DESCRIPTION
# Description

The mesh map waypoints broke during changes to how we handle waypoints, this fixes it.

This PR does the following:
- Fix waypoint handling for `autonav_mesh`

Fixes #644 

# Testing steps (If relevant)
## Test Case 1
1. Run `roslaunch igvc_gazebo autonav_mesh.launch`

Expectation: The map launches properly with the correct waypoints.

# Self Checklist
- [X] I have formatted my code using `make format`
- [X] I have tested that the new behaviour works 
