### PR TITLE
Bug/rviz nav goal cancel

### DIFF
--- a/igvc_navigation/src/navigation_server/navigation_server.cpp
+++ b/igvc_navigation/src/navigation_server/navigation_server.cpp
@@ -29,7 +29,6 @@ NavigationServer::NavigationServer()
 
 void NavigationServer::cancel()
 {
-
   ROS_DEBUG_STREAM_NAMED("nav_server", "nav_server: cancel method called!");
   current_state_ = CANCELED;
 

--- a/igvc_navigation/src/navigation_server/navigation_server.h
+++ b/igvc_navigation/src/navigation_server/navigation_server.h
@@ -64,8 +64,8 @@ private:
 
   ros::Time start_time_;
 
-  ros::Time time_of_last_get_path;
-  ros::Duration time_between_get_path = ros::Duration(0.5);
+  ros::Time time_of_last_get_path_;
+  ros::Duration time_between_get_path_ = ros::Duration(0.5);
 
   igvc_msgs::NavigateWaypointFeedback move_base_feedback_;
   geometry_msgs::PoseStamped previous_oscillation_pose_;
@@ -77,8 +77,6 @@ private:
   void start(GoalHandle goal_handle);
 
   void cancel();
-
-  void processLoop();
 
   void runGetPath();
 


### PR DESCRIPTION
Description
Fixes the issue of not being able to override goals with rviz.

This PR does the following:
- Removes `processLoop`
- Makes it so `actionExePathFeedback` occasionally calls `runGetPath`

Fixes #646 

# Testing steps (If relevant)
## Test Case 1
1. run `roslaunch igvc_gazebo qualification.launch`
2. run `roslaunch igvc_navigation navigation_simulation read_from_file:=false`
3. run rviz
4. Using the 2D NavGoal option, set a navigation goal.
5. Before the robot reaches the goal, set another goal.

Expectation: The robot stops going towards the first goal and starts going towards the second goal.
# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
