### PR TITLE
Updated port to 5333 (IGVC)

### DIFF
--- a/igvc_platform/launch/motor_controller.launch
+++ b/igvc_platform/launch/motor_controller.launch
@@ -2,7 +2,7 @@
     <!-- MOTOR CONTROLLER -->
     <node name="motor_controller" pkg="igvc_platform" type="motor_controller" output="screen">
           <param name="ip_addr" type="str" value="192.168.1.20"/>
-          <param name="port" type="int" value="7"/>
+          <param name="port" type="int" value="5333"/>
           <param name="p_l" type="double" value="0.0"/>
           <param name="p_r" type="double" value="0.0"/>
           <param name="d_l" type="double" value="0.0"/>


### PR DESCRIPTION
# Description
Changes in our firmware changed the port to 5333, but we never actually updated the address.

This PR does the following:
- Updates the port to 5333

Fixes #649

# Testing steps (If relevant)
## Test Case 1
1. Run `motor_controller.launch`

Expectation: It doesn't crash

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
