### PR TITLE
Bugfix fast_segment_filter and documented pointcloud_filter.yaml

### DIFF
--- a/igvc_perception/config/pointcloud_filter.yaml
+++ b/igvc_perception/config/pointcloud_filter.yaml
@@ -19,12 +19,12 @@ pointcloud_filter:
         start_angle: -2.0
         end_angle: 2.0
     fast_segment_filter:
-        ground_topic: "/ground"
-        nonground_topic: "/nonground"
+        ground_topic: "/ground"         # Extra topic to publish ground points to
+        nonground_topic: "/nonground"   # Extra topic to publish nonground points to (also published to occupied topic above)
         num_segments: 360               # Number of pie slices to break the world into
-        error_t: .1                     # Threshold on the error for line models. Higher threshold means longer lines with more points, smller means shorter lines with less points
+        error_t: .1                     # Threshold on the error for line models (meters^2). Higher threshold means longer lines with more points, smller means shorter lines with less points
         slope_t: .6                     # Threshold on slope for defining if a line is ground or not
-        dist_t: .3                      # Threshold on height of a line. If all points in a line are below this, then the line is ground
+        dist_t: .3                      # Threshold on height of a line (meters). If all points in a line are below this, then the line is ground
         debug_viz: true                 # If true, debug visualization is published to /pointcloud_filter_node/pointcloud_filter/Lines_array
     frames:
         base_footprint: "base_footprint"

--- a/igvc_perception/config/pointcloud_filter.yaml
+++ b/igvc_perception/config/pointcloud_filter.yaml
@@ -21,12 +21,11 @@ pointcloud_filter:
     fast_segment_filter:
         ground_topic: "/ground"
         nonground_topic: "/nonground"
-        num_segments: 270
-        error_t: .015
-        slope_t: .3
-        intercept_z_t: 100
-        dist_t: .1
-        debug_viz: true
+        num_segments: 360               # Number of pie slices to break the world into
+        error_t: .1                     # Threshold on the error for line models. Higher threshold means longer lines with more points, smller means shorter lines with less points
+        slope_t: .6                     # Threshold on slope for defining if a line is ground or not
+        dist_t: .3                      # Threshold on height of a line. If all points in a line are below this, then the line is ground
+        debug_viz: true                 # If true, debug visualization is published to /pointcloud_filter_node/pointcloud_filter/Lines_array
     frames:
         base_footprint: "base_footprint"
     timeout_duration: 0.5

--- a/igvc_perception/include/pointcloud_filter/fast_segment_filter/fast_segment_filter_config.h
+++ b/igvc_perception/include/pointcloud_filter/fast_segment_filter/fast_segment_filter_config.h
@@ -10,7 +10,6 @@ struct FastSegmentFilterConfig
   int num_segments;
   double error_t;
   double slope_t;
-  double intercept_z_t;
   double dist_t;
   std::string ground_topic;
   std::string nonground_topic;

--- a/igvc_perception/src/pointcloud_filter/fast_segment_filter/fast_segment_filter.cpp
+++ b/igvc_perception/src/pointcloud_filter/fast_segment_filter/fast_segment_filter.cpp
@@ -25,6 +25,7 @@ void FastSegmentFilter::filter(pointcloud_filter::Bundle &bundle)
   ground_pub_.publish(ground_points_);
   nonground_pub_.publish(nonground_points_);
 
+  bundle.occupied_pointcloud->header = bundle.pointcloud->header;
   bundle.occupied_pointcloud->points = std::move(nonground_points_.points);
 }
 
@@ -203,7 +204,7 @@ int FastSegmentFilter::getSegIdFromPoint(const velodyne_pointcloud::PointXYZIR p
 
 double FastSegmentFilter::getDistanceFromPoint(const velodyne_pointcloud::PointXYZIR point)
 {
-  return std::hypot(point.x, point.y);
+  return std::hypot(point.x, point.y, point.z);
 }
 
 double FastSegmentFilter::getDistanceBetweenPoints(const velodyne_pointcloud::PointXYZIR point1,
@@ -225,7 +226,7 @@ bool FastSegmentFilter::evaluateIsGround(Line &l)
   double dz = l.end_point_.point_.z - l.start_point_.point_.z;
   double len_xy = std::hypot(dx, dy);
   double slope = std::abs(dz) / len_xy;
-  return slope < config_.slope_t && l.end_point_.point_.z < config_.intercept_z_t;
+  return slope < config_.slope_t;
 }
 
 void FastSegmentFilter::debugViz()

--- a/igvc_perception/src/pointcloud_filter/fast_segment_filter/fast_segment_filter_config.cpp
+++ b/igvc_perception/src/pointcloud_filter/fast_segment_filter/fast_segment_filter_config.cpp
@@ -13,7 +13,6 @@ FastSegmentFilterConfig::FastSegmentFilterConfig(const ros::NodeHandle& nh)
   assertions::getParam(child_nh, "num_segments", num_segments);
   assertions::getParam(child_nh, "error_t", error_t);
   assertions::getParam(child_nh, "slope_t", slope_t);
-  assertions::getParam(child_nh, "intercept_z_t", intercept_z_t);
   assertions::getParam(child_nh, "dist_t", dist_t);
   assertions::getParam(child_nh, "debug_viz", debug_viz);
 }

--- a/igvc_perception/src/pointcloud_filter/pointcloud_filter.cpp
+++ b/igvc_perception/src/pointcloud_filter/pointcloud_filter.cpp
@@ -48,8 +48,6 @@ void PointcloudFilter::pointcloudCallback(const PointCloud::ConstPtr& raw_pointc
 
   tf_transform_filter_.transform(*bundle.pointcloud, *bundle.pointcloud, base_frame, timeout);
 
-  ground_filter_.filter(bundle);
-
   tf_transform_filter_.transform(*bundle.occupied_pointcloud, *bundle.occupied_pointcloud, lidar_frame, timeout);
   raycast_filter_.filter(bundle);
 


### PR DESCRIPTION
# Description

Small fixes and documentation for `fast_segment_filter`.

This PR does the following:
- Documents `pointcloud_filter.yaml`
- Fixes message header for `occupied_pointcloud`
- Switches `pointcloud_filter` to use `fast_segment_filter` instead of `ground_filter`
- Small change to `fast_segment_filter`

Fixes #658 and #659

# Testing steps (If relevant)
1. Run a rosbag or `roslaunch igvc_gazebo autonav.launch` for simulation
2. Run `roslaunch igvc_navigation navigation_simulation.launch`
3. Open rviz and check messages are being published to `lidar/occupied`
4. Play around with `fast_segment_filter` parameters in `igvc_perception/config/pointcloud_filter.yaml` and check it changes the outputs to the `lidar/occupied` and debug_viz topics

Expectation: `lidar/occupied` should have nonground points and you should be able to change performance of the node by modifying `fast_segment_filter` parameters.

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
