### PR TITLE
Removed duplicate key names in yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,42 +1,42 @@
-defaults: &dir
+dir: &dir
   working_directory: ~/catkin_ws
 
-defaults: &image
+image: &image
   docker:
   - image: robojackets/igvc-baseimage:latest
 
-defaults: &install_deps
+install_deps: &install_deps
   run: apt-get update && rosdep update && rosdep install -iy --from-paths ./src
 
-defaults: &save_src_cache
+save_src_cache: &save_src_cache
   save_cache:
     key: source-v1-{{ .Branch }}-{{ .Revision }}
     paths:
     - ".git"
-defaults: &load_src_cache
+load_src_cache: &load_src_cache
   restore_cache:
     keys:
     - source-v1-{{ .Branch }}-{{ .Revision }}
     - source-v1-{{ .Branch }}-
     - source-v1-
-defaults: &save_compile_cache
+save_compile_cache: &save_compile_cache
   save_cache:
     key: ccache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
     paths:
     - ~/.ccache
-defaults: &load_compile_cache
+load_compile_cache: &load_compile_cache
   restore_cache:
     keys:
     - ccache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
     - ccache-{{ arch }}-{{ .Branch }}
     - ccache-{{ arch }}
     - ccache-
-defaults: &save_test_cache
+save_test_cache: &save_test_cache
   save_cache:
     key: ccache-test-{{ arch }}-{{ .Branch }}-{{ .Revision }}
     paths:
     - ~/.ccache
-defaults: &load_test_cache
+load_test_cache: &load_test_cache
   restore_cache:
     keys:
     - ccache-test-{{ arch }}-{{ .Branch }}-{{ .Revision }}
@@ -44,13 +44,13 @@ defaults: &load_test_cache
     - ccache-test-{{ arch }}
     - ccache-test-
 
-defaults: &save_workspace
+save_workspace: &save_workspace
   persist_to_workspace:
     root: ~/catkin_ws
     paths:
     - build/*
     - devel/*
-defaults: &load_workspace
+load_workspace: &load_workspace
   attach_workspace:
     at: ~/catkin_ws
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,6 @@ jobs:
           fi
         done
   clang-tidy:
-    working_directory: ~/catkin_ws/src/igvc-software
     <<: *dir
     <<: *image
     steps:

--- a/igvc_navigation/CMakeLists.txt
+++ b/igvc_navigation/CMakeLists.txt
@@ -19,7 +19,6 @@ find_package(catkin REQUIRED COMPONENTS
              pcl_ros
              pcl_conversions
              igvc_utils
-             octomap_ros
              tf_conversions
              robot_localization
              parameter_assertions


### PR DESCRIPTION
# Description
Our `.yaml` is broken because of duplicate keys, and finally circleci made the build break.

This PR does the following:
- Fixes the yaml duplicate keys and other bugs with the `config.yml` file.
- Removes `octomap` from dependencies (since we no longer use it)

Fixes #675 

# Testing steps (If relevant)
## Observe Circle CI builds

Expectation: CircleCI builds properly.

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
