### PR TITLE
Fixed issues in simulation_low

### DIFF
--- a/igvc_gazebo/launch/simulation_low.launch
+++ b/igvc_gazebo/launch/simulation_low.launch
@@ -45,8 +45,6 @@
         <!-- accelerate lidar with GPU -->
         <arg name="gpu" value="$(arg gpu)"/>
     </include>
-    <include file="$(find igvc_perception)/launch/filter_lidar.launch" />
-    <!--  <include file="$(find igvc_perception)/launch/projection.launch" />-->
 
     <include file="$(find igvc_gazebo)/launch/igvc_control.launch" />
 


### PR DESCRIPTION
# Description
Fixes issue in simulation_low.launch

This PR does the following:
- Removes a line in simulation_low.launch that calls for filter_lidar.launch

# Testing steps (If relevant)
## Test Case 1
1. Run `roslaunch igvc_gazebo qual_low.launch`

Expectation: Does not crash.

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
