### PR TITLE
Lowered resolution to same as hardware cameras

### DIFF
--- a/igvc_description/urdf/jessii.urdf.xacro
+++ b/igvc_description/urdf/jessii.urdf.xacro
@@ -286,8 +286,8 @@
               <!-- hov in radians -->
               <horizontal_fov>1.2290609</horizontal_fov>
               <image>
-                <width>1920</width>
-                <height>1080</height>
+                <width>640</width>
+                <height>480</height>
               </image>
               <clip>
                 <near>0.1</near>
@@ -352,8 +352,8 @@
               <!-- hov in radians -->
               <horizontal_fov>1.2290609</horizontal_fov>
               <image>
-                <width>1920</width>
-                <height>1080</height>
+                <width>640</width>
+                <height>480</height>
               </image>
               <clip>
                 <near>0.1</near>
@@ -418,8 +418,8 @@
               <!-- hov in radians -->
               <horizontal_fov>1.2290609</horizontal_fov>
               <image>
-                <width>1920</width>
-                <height>1080</height>
+                <width>640</width>
+                <height>480</height>
               </image>
               <clip>
                 <near>0.1</near>


### PR DESCRIPTION
# Description
Our simulation has cameras output 1920x1080, but the hardware cameras output 640x480. 

This PR does the following:
- Changes simulation to also output 640x480

# Testing steps (If relevant)
## Verify that cameras output 640x480
1. Launch simulation
2. Echo `/cam/*/raw/camera_info`

Expectation: All camera topics output 640x480 images

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
