### PR TITLE
changed how global path is replanned

### DIFF
--- a/igvc_navigation/launch/navigation_server.launch
+++ b/igvc_navigation/launch/navigation_server.launch
@@ -1,6 +1,7 @@
 <launch>
     <node name="navigation_server" pkg="igvc_navigation" type="navigation_server" output="screen">
         <param name="replanning_rate" value="2"/>
+        <param name="max_replanning_tries" value="10"/>
         <param name="recovery_enabled" value="true"/>
         <param name="oscillation_timeout" value="10"/> <!-- Determines how much time between oscillation checks -->
         <param name="oscillation_distance" value="0.2"/><!-- Determines the distance the robot must travel to not be 'oscillating` -->

--- a/igvc_navigation/launch/navigation_server.launch
+++ b/igvc_navigation/launch/navigation_server.launch
@@ -1,5 +1,6 @@
 <launch>
     <node name="navigation_server" pkg="igvc_navigation" type="navigation_server" output="screen">
+        <param name="replanning_rate" value="2"/>
         <param name="recovery_enabled" value="true"/>
         <param name="oscillation_timeout" value="10"/> <!-- Determines how much time between oscillation checks -->
         <param name="oscillation_distance" value="0.2"/><!-- Determines the distance the robot must travel to not be 'oscillating` -->

--- a/igvc_navigation/src/navigation_server/navigation_server.cpp
+++ b/igvc_navigation/src/navigation_server/navigation_server.cpp
@@ -7,15 +7,16 @@ NavigationServer::NavigationServer()
   , recovery_trigger_(NONE)
   , nh_()
   , private_nh_("~")
-  , action_client_get_path_(private_nh_, "/move_base_flex/get_path")
-  , action_client_exe_path_(private_nh_, "/move_base_flex/exe_path")
-  , action_client_recovery_(private_nh_, "/move_base_flex/recovery")
+  , action_client_get_path_(private_nh_, "/move_base_flex/get_path", true)
+  , action_client_exe_path_(private_nh_, "/move_base_flex/exe_path", true)
+  , action_client_recovery_(private_nh_, "/move_base_flex/recovery", true)
   , action_server_(private_nh_, "/move_to_waypoint", boost::bind(&NavigationServer::start, this, _1),
                    boost::bind(&NavigationServer::cancel, this), false)
 {
   ROS_INFO_STREAM_NAMED("nav_server", "Navigation server created.");
   assertions::getParam(private_nh_, "recovery_enabled", recovery_enabled_);
   assertions::getParam(private_nh_, "oscillation_distance", oscillation_distance_);
+  assertions::getParam(private_nh_, "max_replanning_tries", max_replanning_tries_);
 
   double timeout, wait_time, rate;
   assertions::getParam(private_nh_, "oscillation_timeout", timeout);
@@ -173,53 +174,82 @@ void NavigationServer::actionGetPathDone(const actionlib::SimpleClientGoalState 
       break;
   }
 
-  if (navigation_state_ != EXE_PATH)
+  // only start replanning if we are executing path
+  if (navigation_state_ == EXE_PATH)
   {
-    return;
+    current_replanning_tries_ = 0;
+    // prevent other threads from replanning while thread sleeps
+    std::lock_guard<std::mutex> guard(replanning_mtx_);
+    replanning_rate_.reset();
+    replanning_rate_.sleep();
+    // if we are still going along path (not finished),
+    if (navigation_state_ == EXE_PATH &&
+        action_client_get_path_.getState() != actionlib::SimpleClientGoalState::PENDING &&
+        action_client_get_path_.getState() != actionlib::SimpleClientGoalState::ACTIVE)
+    {
+      ROS_INFO_STREAM_NAMED("nav_server", "Start replanning, using the \"get_path\" action!");
+      action_client_get_path_.sendGoal(get_path_goal_,
+                                       boost::bind(&NavigationServer::actionGetPathReplanningDone, this, _1, _2));
+    }
   }
-  std::lock_guard<std::mutex> guard(replanning_mtx_);
-  replanning_rate_.reset();
-  replanning_rate_.sleep();
-  if (navigation_state_ != EXE_PATH ||
-      action_client_get_path_.getState() == actionlib::SimpleClientGoalState::PENDING ||
-      action_client_get_path_.getState() == actionlib::SimpleClientGoalState::ACTIVE)
-    return;
-  ROS_INFO_STREAM_NAMED("nav_server", "Start replanning, using the \"get_path\" action!");
-  action_client_get_path_.sendGoal(get_path_goal_,
-                                   boost::bind(&NavigationServer::actionGetPathReplanningDone, this, _1, _2));
 }
 
 void NavigationServer::actionGetPathReplanningDone(const actionlib::SimpleClientGoalState &state,
                                                    const mbf_msgs::GetPathResultConstPtr &result_ptr)
 {
-  if (navigation_state_ != EXE_PATH)
-    return;
-
-  if (state == actionlib::SimpleClientGoalState::SUCCEEDED)
+  // check if we are executing path
+  if (navigation_state_ == EXE_PATH)
   {
     const mbf_msgs::GetPathResult &result = *(result_ptr.get());
-    ROS_DEBUG_STREAM_NAMED("move_base", "Replanning succeeded; sending a goal to \"exe_path\" with the new plan");
-    nav_msgs::Path path = result.path;
-    if (fix_goal_poses_)
+    // if get_path was successful, start executing new path
+    if (state == actionlib::SimpleClientGoalState::SUCCEEDED)
     {
-      size_t size = path.poses.size();
-      // change the orientation of the last pose to that of the pose before it
-      path.poses[size - 1].pose.orientation = path.poses[size - 2].pose.orientation;
+      ROS_DEBUG_STREAM_NAMED("nav_server", "Replanning succeeded; sending a goal to \"exe_path\" with the new plan");
+      nav_msgs::Path path = result.path;
+      if (fix_goal_poses_)
+      {
+        size_t size = path.poses.size();
+        // change the orientation of the last pose to that of the pose before it
+        path.poses[size - 1].pose.orientation = path.poses[size - 2].pose.orientation;
+      }
+      runExePath(path);
     }
-    runExePath(path);
+    // if get_path was aborted, retry until we exceed maximum number of tries
+    else if (state == actionlib::SimpleClientGoalState::ABORTED)
+    {
+      if (current_replanning_tries_++ > max_replanning_tries_)
+      {
+        ROS_DEBUG_STREAM_NAMED("nav_server", "Action 'get_path' aborted.");
+        if (attemptRecovery())
+        {
+          recovery_trigger_ = GET_PATH;
+        }
+        else
+        {
+          // copy result from get_path action
+          igvc_msgs::NavigateWaypointResult navigate_waypoint_result;
+          navigate_waypoint_result.outcome = result.outcome;
+          navigate_waypoint_result.message = result.message;
+          ROS_WARN_STREAM_NAMED("nav_server", "Abort the execution of the planner: " << result.message);
+          goal_handle_.setAborted(navigate_waypoint_result, state.getText());
+          navigation_state_ = FAILED;
+        }
+      }
+    }
+
+    // lock replanning mutex and sleep for remaining time
+    {
+      std::lock_guard<std::mutex> guard{ replanning_mtx_ };
+      replanning_rate_.sleep();
+    }
+
+    if (navigation_state_ == EXE_PATH)
+    {
+      ROS_DEBUG_STREAM_NAMED("nav_server", "Next replanning cycle, using the \"get_path\" action!");
+      action_client_get_path_.sendGoal(get_path_goal_,
+                                       boost::bind(&NavigationServer::actionGetPathReplanningDone, this, _1, _2));
+    }
   }
-
-  {
-    std::lock_guard<std::mutex> guard{ replanning_mtx_ };
-    replanning_rate_.sleep();
-  }
-
-  if (navigation_state_ != EXE_PATH)
-    return;
-
-  ROS_DEBUG_STREAM_NAMED("move_base", "Next replanning cycle, using the \"get_path\" action!");
-  action_client_get_path_.sendGoal(get_path_goal_,
-                                   boost::bind(&NavigationServer::actionGetPathReplanningDone, this, _1, _2));
 }
 
 void NavigationServer::runExePath(nav_msgs::Path path)
@@ -442,8 +472,7 @@ void NavigationServer::runNextRecoveryBehavior(const igvc_msgs::NavigateWaypoint
   if (current_recovery_behavior_ == recovery_behaviors_.end())
   {
     ROS_DEBUG_STREAM_NAMED("nav_server", "nav_server: All recovery behaviors failed. Abort recovering and abort the "
-                                         "move_base "
-                                         "action");
+                                         "move_base action");
     goal_handle_.setAborted(navigate_waypoint_result, "All recovery behaviors failed.");
     navigation_state_ = FAILED;
   }

--- a/igvc_navigation/src/navigation_server/navigation_server.cpp
+++ b/igvc_navigation/src/navigation_server/navigation_server.cpp
@@ -105,7 +105,6 @@ void NavigationServer::runGetPath()
 void NavigationServer::actionGetPathDone(const actionlib::SimpleClientGoalState &state,
                                          const mbf_msgs::GetPathResultConstPtr &result_ptr)
 {
-  const mbf_msgs::GetPathResult &result = *(result_ptr.get());
   igvc_msgs::NavigateWaypointResult navigate_waypoint_result;
 
   switch (state.state_)
@@ -113,7 +112,7 @@ void NavigationServer::actionGetPathDone(const actionlib::SimpleClientGoalState 
     case actionlib::SimpleClientGoalState::SUCCEEDED:
     {
       ROS_DEBUG_STREAM_NAMED("nav_server", "nav_server received path from 'get_path'");
-      nav_msgs::Path path = result.path;
+      nav_msgs::Path path = result_ptr->path;
       if (fix_goal_poses_)
       {
         size_t size = path.poses.size();
@@ -148,9 +147,9 @@ void NavigationServer::actionGetPathDone(const actionlib::SimpleClientGoalState 
       else
       {
         // copy result from get_path action
-        navigate_waypoint_result.outcome = result.outcome;
-        navigate_waypoint_result.message = result.message;
-        ROS_WARN_STREAM_NAMED("nav_server", "Abort the execution of the planner: " << result.message);
+        navigate_waypoint_result.outcome = result_ptr->outcome;
+        navigate_waypoint_result.message = result_ptr->message;
+        ROS_WARN_STREAM_NAMED("nav_server", "Abort the execution of the planner: " << result_ptr->message);
         goal_handle_.setAborted(navigate_waypoint_result, state.getText());
         navigation_state_ = FAILED;
       }
@@ -158,8 +157,8 @@ void NavigationServer::actionGetPathDone(const actionlib::SimpleClientGoalState 
     case actionlib::SimpleClientGoalState::PREEMPTED:
       // the get_path action has been preempted.
       // copy result from get_path action
-      navigate_waypoint_result.outcome = result.outcome;
-      navigate_waypoint_result.message = result.message;
+      navigate_waypoint_result.outcome = result_ptr->outcome;
+      navigate_waypoint_result.message = result_ptr->message;
       goal_handle_.setCanceled(navigate_waypoint_result, state.getText());
       navigation_state_ = CANCELED;
       break;
@@ -201,12 +200,11 @@ void NavigationServer::actionGetPathReplanningDone(const actionlib::SimpleClient
   // check if we are executing path
   if (navigation_state_ == EXE_PATH)
   {
-    const mbf_msgs::GetPathResult &result = *(result_ptr.get());
     // if get_path was successful, start executing new path
     if (state == actionlib::SimpleClientGoalState::SUCCEEDED)
     {
       ROS_DEBUG_STREAM_NAMED("nav_server", "Replanning succeeded; sending a goal to 'exe_path' with the new plan");
-      nav_msgs::Path path = result.path;
+      nav_msgs::Path path = result_ptr->path;
       if (fix_goal_poses_)
       {
         size_t size = path.poses.size();
@@ -229,9 +227,9 @@ void NavigationServer::actionGetPathReplanningDone(const actionlib::SimpleClient
         {
           // copy result from get_path action
           igvc_msgs::NavigateWaypointResult navigate_waypoint_result;
-          navigate_waypoint_result.outcome = result.outcome;
-          navigate_waypoint_result.message = result.message;
-          ROS_WARN_STREAM_NAMED("nav_server", "Abort the execution of the planner: " << result.message);
+          navigate_waypoint_result.outcome = result_ptr->outcome;
+          navigate_waypoint_result.message = result_ptr->message;
+          ROS_WARN_STREAM_NAMED("nav_server", "Abort the execution of the planner: " << result_ptr->message);
           goal_handle_.setAborted(navigate_waypoint_result, state.getText());
           navigation_state_ = FAILED;
         }

--- a/igvc_navigation/src/navigation_server/navigation_server.cpp
+++ b/igvc_navigation/src/navigation_server/navigation_server.cpp
@@ -177,7 +177,7 @@ void NavigationServer::actionGetPathDone(const actionlib::SimpleClientGoalState 
   {
     return;
   }
-  boost::lock_guard<boost::mutex> guard(replanning_mtx_);
+  std::lock_guard<std::mutex> guard(replanning_mtx_);
   replanning_rate_.reset();
   replanning_rate_.sleep();
   if (navigation_state_ != EXE_PATH ||
@@ -209,9 +209,10 @@ void NavigationServer::actionGetPathReplanningDone(const actionlib::SimpleClient
     runExePath(path);
   }
 
-  replanning_mtx_.lock();
-  replanning_rate_.sleep();
-  replanning_mtx_.unlock();
+  {
+    std::lock_guard<std::mutex> guard{ replanning_mtx_ };
+    replanning_rate_.sleep();
+  }
 
   if (navigation_state_ != EXE_PATH)
     return;

--- a/igvc_navigation/src/navigation_server/navigation_server.h
+++ b/igvc_navigation/src/navigation_server/navigation_server.h
@@ -13,6 +13,8 @@
 #include <igvc_msgs/NavigateWaypointAction.h>
 #include <igvc_msgs/NavigateWaypointFeedback.h>
 
+#include <mutex>
+
 class NavigationServer
 {
 public:
@@ -65,7 +67,7 @@ private:
   ros::Time start_time_;
 
   ros::Rate replanning_rate_ = ros::Rate(1.0);
-  boost::mutex replanning_mtx_;
+  std::mutex replanning_mtx_;
 
   igvc_msgs::NavigateWaypointFeedback move_base_feedback_;
   geometry_msgs::PoseStamped previous_oscillation_pose_;

--- a/igvc_navigation/src/navigation_server/navigation_server.h
+++ b/igvc_navigation/src/navigation_server/navigation_server.h
@@ -40,9 +40,9 @@ private:
   // params
   bool recovery_enabled_ = true;
 
-  NavigationState current_state_;
+  NavigationState navigation_state_;
   NavigationState recovery_trigger_;
-  GoalHandle current_goal_handle_;
+  GoalHandle goal_handle_;
   bool fix_goal_poses_ = true;
 
   ros::NodeHandle nh_;
@@ -64,8 +64,8 @@ private:
 
   ros::Time start_time_;
 
-  ros::Time time_of_last_get_path_;
-  ros::Duration time_between_get_path_ = ros::Duration(0.5);
+  ros::Rate replanning_rate_ = ros::Rate(1.0);
+  boost::mutex replanning_mtx_;
 
   igvc_msgs::NavigateWaypointFeedback move_base_feedback_;
   geometry_msgs::PoseStamped previous_oscillation_pose_;
@@ -82,6 +82,9 @@ private:
 
   void actionGetPathDone(const actionlib::SimpleClientGoalState &state,
                          const mbf_msgs::GetPathResultConstPtr &result_ptr);
+
+  void actionGetPathReplanningDone(const actionlib::SimpleClientGoalState &state,
+                                   const mbf_msgs::GetPathResultConstPtr &result_ptr);
 
   void runExePath(nav_msgs::Path path);
 

--- a/igvc_navigation/src/navigation_server/navigation_server.h
+++ b/igvc_navigation/src/navigation_server/navigation_server.h
@@ -47,28 +47,34 @@ private:
   GoalHandle goal_handle_;
   bool fix_goal_poses_ = true;
 
+  // ros
   ros::NodeHandle nh_;
+  ros::NodeHandle private_nh_;
   ros::Publisher current_goal_pose_publisher_;
 
-  ros::NodeHandle private_nh_;
+  // action lib
   ActionClientGetPath action_client_get_path_;
   ActionClientExePath action_client_exe_path_;
   ActionClientRecovery action_client_recovery_;
+  actionlib::ActionServer<igvc_msgs::NavigateWaypointAction> action_server_;
 
+  // recovery
   std::vector<std::string> recovery_behaviors_;
   std::vector<std::string> default_recovery_behaviors_ = { "back_up_recovery" };
   std::vector<std::string>::iterator current_recovery_behavior_;
 
+  // goals
   mbf_msgs::GetPathGoal get_path_goal_;
   std::string exe_path_controller_;
 
-  actionlib::ActionServer<igvc_msgs::NavigateWaypointAction> action_server_;
-
-  ros::Time start_time_;
-
+  // replanning
   ros::Rate replanning_rate_ = ros::Rate(1.0);
   std::mutex replanning_mtx_;
+  int max_replanning_tries_;
+  int current_replanning_tries_;
 
+  // exe_path feedback / oscillation
+  ros::Time start_time_;
   igvc_msgs::NavigateWaypointFeedback move_base_feedback_;
   geometry_msgs::PoseStamped previous_oscillation_pose_;
   ros::Time last_oscillation_reset_;


### PR DESCRIPTION
# Description

Fixes an issue where `navigation_server` would sometimes keep path planning even when the goal was reached.

This PR does the following:
- Changes the function call for runGetPath() to be at the end of actionGetPathDone() with a timer and mutex lock. This is more how like move_base_flex did it.

# Testing steps (If relevant)
## Test Case 1
1. open a simulation
2. run `navigation_simulation.launch` with `read_from_file:=false`
3. open rviz
4. set a goal close to the robot

Expectation: When the robot reaches the goal, it will not attempt to plan again. This was a rare occurrence under normal circumstances, so multiple goals should be sent.

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
