### PR TITLE
Ignore kindr in circleci rosdep install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ image: &image
   - image: robojackets/igvc-baseimage:latest
 
 install_deps: &install_deps
-  run: apt-get update && rosdep update && rosdep install -iy --from-paths ./src
+  run: apt-get update && rosdep update && rosdep install -iy --from-paths ./src --skip-keys='kindr'
 
 save_src_cache: &save_src_cache
   save_cache:


### PR DESCRIPTION
# Description

This PR does the following:
- Adds `kindr` to the `--skip-keys` list so that ros doesn't try to find `kindr` (and fail) when building

# Testing steps (If relevant)
## CI builds
- Check the CI build for this PR

Expectation: It builds successfully.

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
