### PR TITLE
uncommented sim_detector for simulation_low

### DIFF
--- a/igvc_gazebo/launch/simulation_low.launch
+++ b/igvc_gazebo/launch/simulation_low.launch
@@ -60,7 +60,7 @@
     </node>
 
     <!-- Publish segmented camera images -->
-<!--    <include file="$(find igvc_gazebo)/launch/sim_detector.launch" />-->
+    <include file="$(find igvc_gazebo)/launch/sim_detector.launch" />
 
     <include file="$(find igvc_utils)/launch/imu_to_rpy.launch" />
 


### PR DESCRIPTION
# Description
`simulation_low.launch` was broken because `sim_detector.launch`

This PR does the following:
- Uncomments it so nav stack works

# Testing steps (If relevant)
## Nav stack works
1. Do the thing.

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
