### PR TITLE
Prevent barrels from floating in low performance

### DIFF
--- a/igvc_description/urdf/models/barrels_low/model.sdf
+++ b/igvc_description/urdf/models/barrels_low/model.sdf
@@ -15,6 +15,7 @@
         </inertia>
       </inertial>
       <collision name='collision'>
+        <pose> 0 0 0.5 0 0 0 </pose>
         <geometry>
            <cylinder>
              <radius>0.3</radius>


### PR DESCRIPTION
# Description

The barrels in low performance mode were floating. No more! Only Jessiii has the right to float.

This PR does the following:
- Grounds barrels

# Testing steps (If relevant)
## Test Case 1
1. Launch `autonav_low.launch`
2. Launch `qual_low.launch`

Expectation: Barrels should be on the ground plane.

# Self Checklist
- [X] I have formatted my code using `make format`
- [X] I have tested that the new behaviour works 
