### PR TITLE
Added raw magnetometer topic to simulation

### DIFF
--- a/igvc_description/urdf/jessii.urdf.xacro
+++ b/igvc_description/urdf/jessii.urdf.xacro
@@ -590,7 +590,7 @@
       <frameId>imu</frameId>
       <topicName>/imu</topicName>
       <rpyOffsets>0 0 0</rpyOffsets>
-      <gaussianNoise>0.00000001</gaussianNoise>
+      <gaussianNoise>0.00000005</gaussianNoise>
       <accelDrift>0.00000001 0.00000001 0.00000001</accelDrift>
       <accelDriftFrequency>0.00000001 0.00000001 0.00000001</accelDriftFrequency>
       <accelGaussianNoise>0.00000001 0.00000001 0.00000001</accelGaussianNoise>
@@ -610,7 +610,7 @@
       <frameId>magnetometer</frameId>
       <topicName>/magnetometer</topicName>
       <rpyOffsets>0 0 0</rpyOffsets>
-      <gaussianNoise>0.00000001</gaussianNoise>
+      <gaussianNoise>0.00000005</gaussianNoise>
       <accelDrift>0.00000001 0.00000001 0.00000001</accelDrift>
       <accelDriftFrequency>0.00000001 0.00000001 0.00000001</accelDriftFrequency>
       <accelGaussianNoise>0.00000001 0.00000001 0.00000001</accelGaussianNoise>
@@ -621,6 +621,20 @@
       <headingDriftFrequency>0.0 0.0 0.0</headingDriftFrequency>
       <headingGaussianNoise>0.0 0.0 0.0</headingGaussianNoise>
       <yawOffset>1.57079632679</yawOffset>
+    </plugin>
+
+    <plugin name="magnetometer" filename="libhector_gazebo_ros_magnetic.so">
+        <updateRate>200.0</updateRate>
+        <magnitude>.0000489162</magnitude>
+        <bodyName>magnetometer</bodyName>
+        <topicName>/magnetometer/vector</topicName>
+        <referenceHeading>0.0</referenceHeading>
+        <declination>-5.2290</declination>
+        <inclination>62.2126</inclination>
+        <offset>0 0 0</offset>
+        <drift>0 0 0</drift>
+        <driftFrequency>0 0 0</driftFrequency>
+        <gaussianNoise>0.00000005 0.00000005 0.00000005</gaussianNoise>
     </plugin>
 
     <plugin filename="libhector_gazebo_ros_gps.so" name="gps">

--- a/igvc_gazebo/CMakeLists.txt
+++ b/igvc_gazebo/CMakeLists.txt
@@ -46,6 +46,7 @@ install(DIRECTORY config/
     FILES_MATCHING PATTERN "*.yaml"
     )
 
+add_subdirectory(nodes/magnetometer)
 add_subdirectory(nodes/control)
 add_subdirectory(nodes/scan_to_pointcloud)
 add_subdirectory(nodes/ground_truth)

--- a/igvc_gazebo/launch/simulation.launch
+++ b/igvc_gazebo/launch/simulation.launch
@@ -53,6 +53,11 @@
         <param name="ground_truth_pub_topic" value="/ground_truth"/>
     </node>
 
+    <node name="mag_republisher" pkg="igvc_gazebo" type="mag_republisher" output="screen">
+        <param name="mag_sub_topic" value="/magnetometer/vector"/>
+        <param name="mag_pub_topic" value="/magnetometer_mag"/>
+    </node>
+
     <node pkg="igvc_utils" type="quaternion_to_rpy" name="ground_truth_to_rpy" respawn="true" output="screen">
         <param name="topics/quaternion" value="/ground_truth"/>
         <param name="topics/rpy" value="/ground_truth_rpy"/>

--- a/igvc_gazebo/launch/simulation.launch
+++ b/igvc_gazebo/launch/simulation.launch
@@ -56,6 +56,7 @@
     <node name="mag_republisher" pkg="igvc_gazebo" type="mag_republisher" output="screen">
         <param name="mag_sub_topic" value="/magnetometer/vector"/>
         <param name="mag_pub_topic" value="/magnetometer_mag"/>
+        <param name="mag_field_variance" value = "0.000001"/>
     </node>
 
     <node pkg="igvc_utils" type="quaternion_to_rpy" name="ground_truth_to_rpy" respawn="true" output="screen">

--- a/igvc_gazebo/launch/simulation_low.launch
+++ b/igvc_gazebo/launch/simulation_low.launch
@@ -59,6 +59,11 @@
         <param name="message_type" value="odometry"/>
     </node>
 
+    <node name="mag_republisher" pkg="igvc_gazebo" type="mag_republisher" output="screen">
+        <param name="mag_sub_topic" value="/magnetometer/vector"/>
+        <param name="mag_pub_topic" value="/magnetometer_mag"/>
+    </node>
+
     <!-- Publish segmented camera images -->
     <include file="$(find igvc_gazebo)/launch/sim_detector.launch" />
 

--- a/igvc_gazebo/launch/simulation_low.launch
+++ b/igvc_gazebo/launch/simulation_low.launch
@@ -62,6 +62,7 @@
     <node name="mag_republisher" pkg="igvc_gazebo" type="mag_republisher" output="screen">
         <param name="mag_sub_topic" value="/magnetometer/vector"/>
         <param name="mag_pub_topic" value="/magnetometer_mag"/>
+        <param name="mag_field_variance" value = "0.000001"/>
     </node>
 
     <!-- Publish segmented camera images -->

--- a/igvc_gazebo/nodes/magnetometer/CMakeLists.txt
+++ b/igvc_gazebo/nodes/magnetometer/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(mag_republisher main.cpp)
+add_dependencies(mag_republisher ${catkin_EXPORTED_TARGETS})
+target_link_libraries(mag_republisher ${catkin_LIBRARIES})
+
+install(
+        TARGETS mag_republisher
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/igvc_gazebo/nodes/magnetometer/main.cpp
+++ b/igvc_gazebo/nodes/magnetometer/main.cpp
@@ -2,8 +2,8 @@
 #include <geometry_msgs/Vector3Stamped.h>
 #include <sensor_msgs/MagneticField.h>
 
-ros::Publisher g_mag_field_pub_;
-static double g_mag_field_covar_;
+ros::Publisher g_mag_field_pub;
+static double g_mag_field_covar;
 
 void magCallback(const geometry_msgs::Vector3Stamped& msg)
 {
@@ -14,10 +14,8 @@ void magCallback(const geometry_msgs::Vector3Stamped& msg)
   magnet_msg.magnetic_field.x = msg.vector.x;
   magnet_msg.magnetic_field.y = msg.vector.y;
   magnet_msg.magnetic_field.z = msg.vector.z;
-  magnet_msg.magnetic_field_covariance = {
-    g_mag_field_covar_, 0, 0, 0, g_mag_field_covar_, 0, 0, 0, g_mag_field_covar_
-  };
-  g_mag_field_pub_.publish(magnet_msg);
+  magnet_msg.magnetic_field_covariance = { g_mag_field_covar, 0, 0, 0, g_mag_field_covar, 0, 0, 0, g_mag_field_covar };
+  g_mag_field_pub.publish(magnet_msg);
 }
 
 int main(int argc, char** argv)
@@ -27,8 +25,8 @@ int main(int argc, char** argv)
   ros::NodeHandle pnh("~");
   std::string sub_topic = pnh.param("mag_sub_topic", std::string("/magnetometer/vector"));
   std::string pub_topic = pnh.param("mag_pub_topic", std::string("/magnetometer_mag"));
-  g_mag_field_covar_ = pnh.param("mag_field_variance", 1e-6);
-  g_mag_field_pub_ = nh.advertise<sensor_msgs::MagneticField>(pub_topic, 10);
+  g_mag_field_covar = pnh.param("mag_field_variance", 1e-6);
+  g_mag_field_pub = nh.advertise<sensor_msgs::MagneticField>(pub_topic, 10);
   ros::Subscriber scan_sub = nh.subscribe(sub_topic, 1, magCallback);
   ros::spin();
 }

--- a/igvc_gazebo/nodes/magnetometer/main.cpp
+++ b/igvc_gazebo/nodes/magnetometer/main.cpp
@@ -2,8 +2,8 @@
 #include <geometry_msgs/Vector3Stamped.h>
 #include <sensor_msgs/MagneticField.h>
 
-ros::Publisher mag_field_pub_;
-static double mag_field_covar;
+ros::Publisher g_mag_field_pub_;
+static double g_mag_field_covar_;
 
 void magCallback(const geometry_msgs::Vector3Stamped& msg)
 {
@@ -14,8 +14,10 @@ void magCallback(const geometry_msgs::Vector3Stamped& msg)
   magnet_msg.magnetic_field.x = msg.vector.x;
   magnet_msg.magnetic_field.y = msg.vector.y;
   magnet_msg.magnetic_field.z = msg.vector.z;
-  magnet_msg.magnetic_field_covariance = { mag_field_covar, 0, 0, 0, mag_field_covar, 0, 0, 0, mag_field_covar };
-  mag_field_pub_.publish(magnet_msg);
+  magnet_msg.magnetic_field_covariance = {
+    g_mag_field_covar_, 0, 0, 0, g_mag_field_covar_, 0, 0, 0, g_mag_field_covar_
+  };
+  g_mag_field_pub_.publish(magnet_msg);
 }
 
 int main(int argc, char** argv)
@@ -25,8 +27,8 @@ int main(int argc, char** argv)
   ros::NodeHandle pnh("~");
   std::string sub_topic = pnh.param("mag_sub_topic", std::string("/magnetometer/vector"));
   std::string pub_topic = pnh.param("mag_pub_topic", std::string("/magnetometer_mag"));
-  mag_field_covar = pnh.param("mag_field_variance", 1e-6);
-  mag_field_pub_ = nh.advertise<sensor_msgs::MagneticField>(pub_topic, 10);
+  g_mag_field_covar_ = pnh.param("mag_field_variance", 1e-6);
+  g_mag_field_pub_ = nh.advertise<sensor_msgs::MagneticField>(pub_topic, 10);
   ros::Subscriber scan_sub = nh.subscribe(sub_topic, 1, magCallback);
   ros::spin();
 }

--- a/igvc_gazebo/nodes/magnetometer/main.cpp
+++ b/igvc_gazebo/nodes/magnetometer/main.cpp
@@ -3,6 +3,7 @@
 #include <sensor_msgs/MagneticField.h>
 
 ros::Publisher mag_field_pub_;
+static double mag_field_covar;
 
 void magCallback(const geometry_msgs::Vector3Stamped& msg)
 {
@@ -13,7 +14,7 @@ void magCallback(const geometry_msgs::Vector3Stamped& msg)
   magnet_msg.magnetic_field.x = msg.vector.x;
   magnet_msg.magnetic_field.y = msg.vector.y;
   magnet_msg.magnetic_field.z = msg.vector.z;
-  magnet_msg.magnetic_field_covariance = { 1e-6, 0, 0, 0, 1e-6, 0, 0, 0, 1e-6 };
+  magnet_msg.magnetic_field_covariance = { mag_field_covar, 0, 0, 0, mag_field_covar, 0, 0, 0, mag_field_covar };
   mag_field_pub_.publish(magnet_msg);
 }
 
@@ -24,6 +25,7 @@ int main(int argc, char** argv)
   ros::NodeHandle pnh("~");
   std::string sub_topic = pnh.param("mag_sub_topic", std::string("/magnetometer/vector"));
   std::string pub_topic = pnh.param("mag_pub_topic", std::string("/magnetometer_mag"));
+  mag_field_covar = pnh.param("mag_field_variance", 1e-6);
   mag_field_pub_ = nh.advertise<sensor_msgs::MagneticField>(pub_topic, 10);
   ros::Subscriber scan_sub = nh.subscribe(sub_topic, 1, magCallback);
   ros::spin();

--- a/igvc_gazebo/nodes/magnetometer/main.cpp
+++ b/igvc_gazebo/nodes/magnetometer/main.cpp
@@ -1,0 +1,30 @@
+#include <ros/ros.h>
+#include <geometry_msgs/Vector3Stamped.h>
+#include <sensor_msgs/MagneticField.h>
+
+ros::Publisher mag_field_pub_;
+
+void magCallback(const geometry_msgs::Vector3Stamped& msg)
+{
+  sensor_msgs::MagneticField magnet_msg;
+  magnet_msg.header.seq = msg.header.seq;
+  magnet_msg.header.stamp = msg.header.stamp;
+  magnet_msg.header.frame_id = msg.header.frame_id;
+  magnet_msg.magnetic_field.x = msg.vector.x;
+  magnet_msg.magnetic_field.y = msg.vector.y;
+  magnet_msg.magnetic_field.z = msg.vector.z;
+  magnet_msg.magnetic_field_covariance = { 1e-6, 0, 0, 0, 1e-6, 0, 0, 0, 1e-6 };
+  mag_field_pub_.publish(magnet_msg);
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "mag_republisher");
+  ros::NodeHandle nh;
+  ros::NodeHandle pnh("~");
+  std::string sub_topic = pnh.param("mag_sub_topic", std::string("/magnetometer/vector"));
+  std::string pub_topic = pnh.param("mag_pub_topic", std::string("/magnetometer_mag"));
+  mag_field_pub_ = nh.advertise<sensor_msgs::MagneticField>(pub_topic, 10);
+  ros::Subscriber scan_sub = nh.subscribe(sub_topic, 1, magCallback);
+  ros::spin();
+}


### PR DESCRIPTION
# Description

This PR does the following:
- adds a plugin to gazebo so it publishes raw magnetometer data
- adds a conversion node so that the message type matches the message type published by the real imu

Fixes #699 

# Testing steps (If relevant)
## Test Case 1
1. catkin_make
2. `roslaunch igvc_gazebo qual_low.launch`
3. check to see `/magnetometer_mag` is being published and that it is of type `sensor_msgs/MagneticField`
4. launch `qualification.launch` and check that it also publishes the correct message type to `/magnetometer_mag`

Expectation: all simulations publish to the `/magnetometer_mag` topic

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
