### PR TITLE
Fix kindr and external dependencies

### DIFF
--- a/cmake/ensure_submodules.cmake
+++ b/cmake/ensure_submodules.cmake
@@ -1,6 +1,6 @@
 find_package(Git QUIET)
 
-set(EXTERNAL_PACKAGES rj-ros-common)
+set(EXTERNAL_PACKAGES rj-ros-common kindr_ros elevation_mapping)
 set(EXTERNAL_PACKAGES_FOUND True)
 
 if(NOT WIN32)

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+if [ ! -d "/usr/local/include/kindr/" ]; then
+    git clone https://github.com/ANYbotics/kindr.git
+    cd kindr
+    mkdir build
+    cd build
+    cmake ..
+    sudo make install
+    cd ../..
+    rm -rf kindr
+fi
+rosdep install -iy --from-paths ../../src --skip-keys='kindr'

--- a/readme.md
+++ b/readme.md
@@ -42,16 +42,10 @@ The repo is comprised of multiple ROS packages and one sandbox folder for miscel
     git clone https://github.com/RoboJackets/igvc-software --recursive
     ```
 
-2. Install kindr library (if not done already):
+2. Install dependencies:
     ```bash
-    git clone https://github.com/ANYbotics/kindr.git
-    cd kindr
-    mkdir build
-    cd build
-    cmake ..
-    sudo make install
-    cd ../..
-    rm -rf kindr
+    cd igvc-software
+    ./install_dependencies.sh
     ```
 
 3. Use `catkin_make` in the workspace to build all the packages:


### PR DESCRIPTION
# Description

The addition of kindr has made our build process longer than expected, and we are missing some new submodules in our cmake files. This PR fixes our external dependencies and makes the installation easier.

This PR does the following:
- Adds an installation script for our dependencies
- Fixes submodule list

# Testing steps (If relevant)
1. Remove kindr installation with `sudo rm -rf "/usr/local/include/kindr/"`
2. Run the script: `./install_dependencies.sh`
3. `catkin_make`

Expectation: The project builds properly

# Self Checklist
- [X] I have formatted my code using `make format`
- [X] I have tested that the new behaviour works 
