### PR TITLE
changed INTER_AREA to INTER_LINEAR

### DIFF
--- a/igvc_gazebo/nodes/sim_color_detector/main.cpp
+++ b/igvc_gazebo/nodes/sim_color_detector/main.cpp
@@ -80,7 +80,7 @@ void handleImage(const sensor_msgs::ImageConstPtr& msg, const sensor_msgs::Camer
     return;
   }
 
-  cv::resize(frame, frame, g_output_size, 0, 0, cv::INTER_AREA);
+  cv::resize(frame, frame, g_output_size, 0, 0, cv::INTER_LINEAR);
   cv::Mat frame_hsv;
   cv::cvtColor(frame, frame_hsv, CV_BGR2HSV);
 


### PR DESCRIPTION
# Description
This PR changes the method used for the interpolation for `cv::resize` used in `sim_color_detector` to attempt to reduce the CPU usage of the node.

Currently, `sim_color_detector` is bottlenecked by the `cv::resize`, which takes up ~60% of the time in the callback. The next highest is `cv::cvtcolor` to convert from RGB to HSV.

The current interpolation method for `cv::resize` is INTER_AREA, which gives bettter interpolation when resizing. However, it is slower than something like INTER_LINEAR, and we don't particularly need a good interpolation.

This PR does the following:
- Changes the interpolation method from INTER_AREA to INTER_LINEAR

# Testing steps (If relevant)
## Check that CPU usage is reduced
1. (On Master) Run simulation. `roslaunch igvc_gazebo autonav.launch`
2. run `htop`
3. Note the `CPU%` of the `sim_color_detector` node. Mine was around 105%.
4. Checkout this branch
5. Do the same

Expectation: CPU% should decrease. Mine dropped to around 80%.

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
