### PR TITLE
Fixed instances where $(find igvc_sandbox) should be used

### DIFF
--- a/igvc_perception/launch/vision.launch
+++ b/igvc_perception/launch/vision.launch
@@ -11,7 +11,7 @@
     <param name="image_resize_width" value="400" />
     <param name="image_resize_height" value="400" />
 
-    <param name="model_path" value="$(find igvc_perception)/../sandbox/models/YS/IGVCModel_135.pt" />
+    <param name="model_path" value="$(find igvc_sandbox)/models/YS/IGVCModel_135.pt" />
 
     <!-- Use cpu instead of GPU (will run very slowly). -->
     <param name="force_cpu" value="false" />

--- a/igvc_platform/launch/camera.launch
+++ b/igvc_platform/launch/camera.launch
@@ -9,7 +9,7 @@
 		    <param name="video_device" type="string" value="/dev/igvc_usb_cam_center" />
 		    <param name="pixel_format" type="string" value="yuyv" />
 		    <param name="camera_frame_id" type="string" value="cam/center" />
-	 	    <param name="camera_info_url" type="string" value="file://$(find igvc_platform)/../sandbox/camera_config/usb_cam_center.yaml" />
+	 	    <param name="camera_info_url" type="string" value="file://$(find igvc_sandbox)/camera_config/usb_cam_center.yaml" />
 		    <param name="camera_name" type="string" value="cam/center/raw" />
 			<param name="framerate" value="30" />
 		</node>
@@ -21,7 +21,7 @@
 		    <param name="video_device" type="string" value="/dev/igvc_usb_cam_right" />
 		    <param name="pixel_format" type="string" value="yuyv" />
 		    <param name="camera_frame_id" type="string" value="cam/right" />
-	 	    <param name="camera_info_url" type="string" value="file://$(find igvc_platform)/../sandbox/camera_config/usb_cam_right.yaml" />
+	 	    <param name="camera_info_url" type="string" value="file://$(find igvc_sandbox)/camera_config/usb_cam_right.yaml" />
 		    <param name="camera_name" type="string" value="cam/center/raw" />
 			<param name="framerate" value="30" />
 		</node>
@@ -33,7 +33,7 @@
 		    <param name="video_device" type="string" value="/dev/igvc_usb_cam_left" />
 		    <param name="pixel_format" type="string" value="yuyv" />
 		    <param name="camera_frame_id" type="string" value="cam/left" />
-	 	    <param name="camera_info_url" type="string" value="file://$(find igvc_platform)/../sandbox/camera_config/usb_cam_left.yaml" />
+	 	    <param name="camera_info_url" type="string" value="file://$(find igvc_sandbox)/camera_config/usb_cam_left.yaml" />
 		    <param name="camera_name" type="string" value="cam/center/raw" />
 			<param name="framerate" value="30" />
 		</node>

--- a/igvc_utils/launch/speed_compare.launch
+++ b/igvc_utils/launch/speed_compare.launch
@@ -3,7 +3,7 @@
 <launch>
 
     <node name="speed_compare" pkg="igvc_utils" type="speed_compare" output="screen">
-    	<param name = "file" type = "string" value = "$(find igvc_utils)/../sandbox/speed_compare/speed_data.csv" />
+    	<param name = "file" type = "string" value = "$(find igvc_sandbox)/speed_compare/speed_data.csv" />
     </node>
 
 </launch>


### PR DESCRIPTION
There were instances were there was some form of `$(find igvc_perception)/../sandbox`, which should be replaced with `$(find igvc_sandbox)`