### PR TITLE
Added required="true" attribute to motor controller node.

### DIFF
--- a/igvc_platform/launch/motor_controller.launch
+++ b/igvc_platform/launch/motor_controller.launch
@@ -1,6 +1,6 @@
 <launch>
     <!-- MOTOR CONTROLLER -->
-    <node name="motor_controller" pkg="igvc_platform" type="motor_controller" output="screen">
+    <node name="motor_controller" pkg="igvc_platform" type="motor_controller" output="screen" required="true">
           <param name="ip_addr" type="str" value="192.168.1.20"/>
           <param name="port" type="int" value="5333"/>
           <param name="p_l" type="double" value="0.0"/>


### PR DESCRIPTION
# Description

This PR sets the motor controller node to have `required="true"`.

Fixes #770 

# Testing steps (If relevant)
## Required works.
1. Run ....
2. Run `rosnode kill ....` on the motor controller node.

Expectation: The entire stack dies when the motor controller node dies.

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
