### PR TITLE
Added required="true" to gps node

### DIFF
--- a/igvc_platform/launch/gps.launch
+++ b/igvc_platform/launch/gps.launch
@@ -5,7 +5,7 @@
     GPS model.
     -->
 <launch>
-    <node name="nmea_serial_driver" pkg="nmea_navsat_driver" type="nmea_serial_driver">
+    <node name="nmea_serial_driver" pkg="nmea_navsat_driver" type="nmea_serial_driver" required="true">
         <param name="port" type="str" value="/dev/igvc_gps" />
         <param name="baud" type="int" value="19200" />
     </node>


### PR DESCRIPTION
# Description

This PR sets the gps node to have required="true"

Fixes #771 

# Testing steps (If relevant)
## Required works
1. Run...
2. Run 'rosnode kill ..." on the gps node

Expectation: The entire stack dies when the controller node dies

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
