### PR TITLE
Added required="true" attribute to imu bottom node

### DIFF
--- a/igvc_platform/launch/imu_bottom.launch
+++ b/igvc_platform/launch/imu_bottom.launch
@@ -1,7 +1,7 @@
 <launch>
     <arg name="calibrate_imu" default="false"/>
     <!-- Bottom IMU -->
-    <node pkg="igvc_platform" name="imu_bottom" type="imu" output="screen" >
+    <node pkg="igvc_platform" name="imu_bottom" type="imu" output="screen" required="true">
         <param name="SERIAL_PORT" type="string" value="/dev/imu_bottom" />
         <param name="frame_id" type="string" value="imu"/>
         <param name="calibrate_imu" value="$(arg calibrate_imu)" />


### PR DESCRIPTION
# Description

This PR sets the imu_bottom node to have required="true"

Fixes #772 

# Testing steps (If relevant)
## Required works
1. Run...
2. Run 'rosnode kill...' on the imu_bottom node

Expectation: The entire stack dies when the motor controller dies.

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
