### PR TITLE
Added required="true" attribute to imu top node

### DIFF
--- a/igvc_platform/launch/imu_top.launch
+++ b/igvc_platform/launch/imu_top.launch
@@ -2,7 +2,7 @@
     <arg name="calibrate_imu" default="false"/>
 
     <!-- Top IMU -->
-    <node pkg="igvc_platform" name="imu_top" type="imu" output="screen" >
+    <node pkg="igvc_platform" name="imu_top" type="imu" output="screen" required="true">
         <!--value="/dev/imu_top"-->
         <param name="SERIAL_PORT" type="string" value="/dev/imu_top" />
 


### PR DESCRIPTION
# Description

This PR sets the imu_top node to have required="true"

Fixes #773 

# Testing steps (If relevant)
## Required works
1. Run...
2. Run 'rosnode kill...' on the imu_top node

Expectation: The entire stack dies when the imu_top node dies.

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
