### PR TITLE
Added the attribute *required="true"* to the node tag

### DIFF
--- a/igvc_navigation/launch/differential_drive.launch
+++ b/igvc_navigation/launch/differential_drive.launch
@@ -3,7 +3,7 @@
 <!-- map.launch -->
 <launch>
 
-    <node name="differential_drive" pkg="igvc_navigation" type="differential_drive" output="screen" >
+    <node name="differential_drive" pkg="igvc_navigation" type="differential_drive" output="screen" required="true">
         <param name="axle_length" value="0.52"/>
         <param name="max_vel" value="2.0"/>
     </node>


### PR DESCRIPTION
# Description

{{ First Issue }}

This PR does the following:
- Adds the attribute `required="true"` to the node tag in the launch file

Fixes #{{ No "required" attribute previously }}

Expectation: Adds `required="true"` to the node tag in differential_drive.launch


