### PR TITLE
Feat/add required to odometer

### DIFF
--- a/igvc_navigation/launch/differential_drive.launch
+++ b/igvc_navigation/launch/differential_drive.launch
@@ -3,7 +3,7 @@
 <!-- map.launch -->
 <launch>
 
-    <node name="differential_drive" pkg="igvc_navigation" type="differential_drive" output="screen" >
+    <node name="differential_drive" pkg="igvc_navigation" type="differential_drive" output="screen" required="true">
         <param name="axle_length" value="0.52"/>
         <param name="max_vel" value="2.0"/>
     </node>

--- a/igvc_navigation/launch/wheel_odometry.launch
+++ b/igvc_navigation/launch/wheel_odometry.launch
@@ -1,6 +1,6 @@
 <!-- odometer.launch -->
 <launch>
-    <node name="odometer" pkg="igvc_navigation" type="odometer" output="screen">
+    <node name="odometer" pkg="igvc_navigation" type="odometer" output="screen" required="true">
     <param name="wheel_sep" type="double" value="0.556"/>
     </node>
 </launch>


### PR DESCRIPTION
# Description

{{ First issue: odometer }}

This PR does the following:
- Adds the field `required="true"` to the odometer node tag of the wheel_odometry.launch file.

Fixes #{{ Not previously a `required="true"` field in the node tag }}

Expectation: Odometer node set to required

