### PR TITLE
Set cnn node in vision.launch to be required.

### DIFF
--- a/igvc_perception/launch/vision.launch
+++ b/igvc_perception/launch/vision.launch
@@ -3,7 +3,7 @@
 
 <launch>
 
-    <node name="cnn" pkg="igvc_perception" type="cnn.py" output="screen" />
+    <node name="cnn" pkg="igvc_perception" type="cnn.py" output="screen required="true" />
 
     <rosparam param="camera_names">["usb_cam_center", "usb_cam_left", "usb_cam_right"]</rosparam>
 


### PR DESCRIPTION
# Description

This PR adds required="true" to the cnn node in vision.launch .

Fixes #768 

# Self Checklist
- [ ] I have formatted my code using `make format`
- [ ] I have tested that the new behaviour works 
