### PR TITLE
Added required="true" to diagnostic_aggregator node in sensors.launch

### DIFF
--- a/igvc_platform/launch/sensors.launch
+++ b/igvc_platform/launch/sensors.launch
@@ -35,7 +35,7 @@
     <include file="$(find igvc_utils)/launch/system_stats.launch" />
 
     <node pkg="diagnostic_aggregator" type="aggregator_node"
-          name="diagnostic_aggregator" >
+          name="diagnostic_aggregator" required="true" >
         <!-- Load the file you made above -->
         <rosparam command="load"
                   file="$(find igvc_platform)/config/analyzers.yaml" />


### PR DESCRIPTION
# Description

This PR adds required="true" to the diagnostic_aggregator node in sensors.launch .

Fixes #769 

# Self Checklist
- [ ] I have formatted my code using `make format`
- [ ] I have tested that the new behaviour works 
