### PR TITLE
Required tag added to node move_base_flex

### DIFF
--- a/igvc_navigation/launch/mbf_navigation.launch
+++ b/igvc_navigation/launch/mbf_navigation.launch
@@ -1,6 +1,6 @@
 <launch>
     <!-- Move Base Flex -->
-    <node pkg="mbf_costmap_nav" type="mbf_costmap_nav" respawn="false" name="move_base_flex" output="screen">
+    <node pkg="mbf_costmap_nav" type="mbf_costmap_nav" respawn="false" name="move_base_flex" output="screen" required="true">
         <param name="tf_timeout" value="1.5"/>
         <param name="planner_frequency" value="2.0"/>
         <param name="planner_max_retries" value="3"/>


### PR DESCRIPTION
# Description

This PR sets the move_base_flex node to have the attribute required="true".

Fixes #758 

# Testing steps (If relevant)
## Test Case 1
1. Run ... 
2. Run rosnode kill ... on the move_base_flex node

Expectation: The entire stack dies when the move_base_flex node is killed/dies.

# Self Checklist
- [ ] I have formatted my code using `make format`
- [ ] I have tested that the new behavior works 
