### PR TITLE
Added attribute required=true to navigation_server node

### DIFF
--- a/igvc_navigation/launch/navigation_server.launch
+++ b/igvc_navigation/launch/navigation_server.launch
@@ -1,5 +1,5 @@
 <launch>
-    <node name="navigation_server" pkg="igvc_navigation" type="navigation_server" output="screen">
+    <node name="navigation_server" pkg="igvc_navigation" type="navigation_server" output="screen" required="true">
         <param name="connection_timeout" value="3.0"/>
         <param name="replanning_rate" value="2"/>
         <param name="max_replanning_tries" value="10"/>


### PR DESCRIPTION
# Description

This PR sets the navigation_server node to have attribute required="true".

Fixes #759 

# Testing steps (If relevant)
## Test Case 1
1. Run ... 
2. Run rosnode kill ... on the navigation_server node.
Expectation: The whole stack should die if the navigation_server node dies/is killed.

# Self Checklist
- [ ] I have formatted my code using `make format`
- [ ] I have tested that the new behaviour works 
