### PR TITLE
Added attribute required=true to navigation_client node

### DIFF
--- a/igvc_navigation/launch/navigation_client.launch
+++ b/igvc_navigation/launch/navigation_client.launch
@@ -1,6 +1,6 @@
 <launch>
     <arg name="read_from_file" default="true"/>
-    <node name="navigation_client" pkg="igvc_navigation" type="navigation_client" output="screen">
+    <node name="navigation_client" pkg="igvc_navigation" type="navigation_client" output="screen" required="true">
         <param name="read_from_file" value="$(arg read_from_file)"/>
     </node>
 </launch>


### PR DESCRIPTION
# Description

This PR sets the navigation_client node to have the attribute required="true".

Fixes #760 

# Testing steps (If relevant)
## Test Case 1
1. Run ...
2. Run rosnode kill ... on the navigation_client node

Expectation: The whole stack should die if the navigation_client node is killed or dies. 

# Self Checklist
- [ ] I have formatted my code using `make format`
- [ ] I have tested that the new behaviour works 
