### PR TITLE
Set system_stats node to be required in system_stats.launch

### DIFF
--- a/igvc_utils/launch/system_stats.launch
+++ b/igvc_utils/launch/system_stats.launch
@@ -1,5 +1,5 @@
 <launch>
-    <node name="system_stats" pkg="igvc_utils" type="system_stats" output="screen">
+    <node name="system_stats" pkg="igvc_utils" type="system_stats" output="screen" required="true">
         <param name="publish_frequency" type="double" value="10" />
     </node>
 </launch>


### PR DESCRIPTION
# Added "required=true" attribute to the system_stats node

This PR does the following:
- Makes the system_stats node be required

Fixes #776 

Expectation: The system_stats node will be required in order to run 

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
