### PR TITLE
Feat/add required to camera launch

### DIFF
--- a/igvc_platform/launch/camera.launch
+++ b/igvc_platform/launch/camera.launch
@@ -4,7 +4,7 @@
 	<arg name="camera" default="center" />
 
 	<group if="$(eval 'center' in arg('camera'))">
-		<node name="usb_cam_center" pkg="usb_cam" type="usb_cam_node">
+		<node name="usb_cam_center" pkg="usb_cam" type="usb_cam_node" required="true">
 		    <param name="path" type="string" value="file://$(find igvc_platform)/../../../"/>
 		    <param name="video_device" type="string" value="/dev/igvc_usb_cam_center" />
 		    <param name="pixel_format" type="string" value="yuyv" />
@@ -16,7 +16,7 @@
 	</group>
 
 	<group if="$(eval 'right' in arg('camera'))">
-		<node name="usb_cam_right" pkg="usb_cam" type="usb_cam_node">
+		<node name="usb_cam_right" pkg="usb_cam" type="usb_cam_node" required="true">
 		    <param name="path" type="string" value="file://$(find igvc_platform)/../../../"/>
 		    <param name="video_device" type="string" value="/dev/igvc_usb_cam_right" />
 		    <param name="pixel_format" type="string" value="yuyv" />
@@ -28,7 +28,7 @@
 	</group>
 
 	<group if="$(eval 'left' in arg('camera'))">
-		<node name="usb_cam_left" pkg="usb_cam" type="usb_cam_node">
+		<node name="usb_cam_left" pkg="usb_cam" type="usb_cam_node" required="true">
 		    <param name="path" type="string" value="file://$(find igvc_platform)/../../../"/>
 		    <param name="video_device" type="string" value="/dev/igvc_usb_cam_left" />
 		    <param name="pixel_format" type="string" value="yuyv" />

--- a/igvc_utils/launch/system_stats.launch
+++ b/igvc_utils/launch/system_stats.launch
@@ -1,5 +1,5 @@
 <launch>
-    <node name="system_stats" pkg="igvc_utils" type="system_stats" output="screen">
+    <node name="system_stats" pkg="igvc_utils" type="system_stats" output="screen" required="true">
         <param name="publish_frequency" type="double" value="10" />
     </node>
 </launch>


### PR DESCRIPTION
# Added "required=true" attribute to the nodes in camera.launch

This PR does the following:
- Makes the usb_cam_center node be required
- Makes the usb_cam_right node be required
- Makes the usb_cam_left node be required

Fixes #774

Expectation: The above nodes will be required in order to run

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
