### PR TITLE
Set nodes to be required in imu_to_rpy.launch

### DIFF
--- a/igvc_utils/launch/imu_to_rpy.launch
+++ b/igvc_utils/launch/imu_to_rpy.launch
@@ -1,11 +1,11 @@
 <launch>
-  <node pkg="igvc_utils" type="quaternion_to_rpy" name="imu_top_to_rpy" respawn="true" output="screen">
+  <node pkg="igvc_utils" type="quaternion_to_rpy" name="imu_top_to_rpy" respawn="true" output="screen" required="true">
     <param name="topics/quaternion" value="/magnetometer"/>
     <param name="topics/rpy" value="/magnetometer_rpy"/>
     <param name="message_type" value="imu"/>
   </node>
 
-  <node pkg="igvc_utils" type="quaternion_to_rpy" name="imu_bottom_to_rpy" respawn="true" output="screen">
+  <node pkg="igvc_utils" type="quaternion_to_rpy" name="imu_bottom_to_rpy" respawn="true" output="screen" required="true">
     <param name="topics/quaternion" value="/imu"/>
     <param name="topics/rpy" value="/imu_rpy"/>
     <param name="message_type" value="imu"/>


### PR DESCRIPTION
# Added "required=true" attribute to nodes in imu_to_rpy.launch

This PR does the following:
- Makes the imu_top_to_rpy node to be required
- Makes the imu_bottom_to_rpy node to be required

Fixes #775 

Expectation: The above nodes will be required in order to run

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
