### PR TITLE
Feat/add required to ekf se

### DIFF
--- a/igvc_navigation/launch/localization.launch
+++ b/igvc_navigation/launch/localization.launch
@@ -44,11 +44,11 @@
       <!-- can do output remapping also -->
     </node>
 
-    <node pkg="robot_localization" type="ekf_localization_node" name="ekf_se" output="screen">
+    <node pkg="robot_localization" type="ekf_localization_node" name="ekf_se" output="screen" required="true">
         <rosparam command="load" file="$(find igvc_navigation)/config/ekf_localization_node_params.yaml"/>
     </node>
 
-    <node pkg="igvc_utils" type="quaternion_to_rpy" name="odometry_filtered_to_rpy" respawn="true" output="screen">
+    <node pkg="igvc_utils" type="quaternion_to_rpy" name="odometry_filtered_to_rpy" respawn="true" output="screen" required="true">
         <param name="topics/quaternion" value="/odometry/filtered"/>
         <param name="topics/rpy" value="/odometry/rpy"/>
         <param name="message_type" value="odometry"/>

--- a/igvc_navigation/launch/localization.launch
+++ b/igvc_navigation/launch/localization.launch
@@ -48,7 +48,7 @@
         <rosparam command="load" file="$(find igvc_navigation)/config/ekf_localization_node_params.yaml"/>
     </node>
 
-    <node pkg="igvc_utils" type="quaternion_to_rpy" name="odometry_filtered_to_rpy" respawn="true" output="screen" required="true">
+    <node pkg="igvc_utils" type="quaternion_to_rpy" name="odometry_filtered_to_rpy"  output="screen" required="true">
         <param name="topics/quaternion" value="/odometry/filtered"/>
         <param name="topics/rpy" value="/odometry/rpy"/>
         <param name="message_type" value="odometry"/>


### PR DESCRIPTION
This PR sets the ekf_se and odometry_filtered_to_rpy to have required="true"

Fixes #757

# Testing steps (If relevant)
##Required Works
1. Run localization.launch
2. Run rosnode kill  on the ekf_se 
3. Run ,,. (again)
4. Run rosnode kill on the odometry_filtered_rpy

Expectation: The entire stack dies when the ekf_se or odometry_filtered_to_rpy node dies.

# Self Checklist
- 

- [x] I have formatted my code using `make format`

- [x] I have tested that the new behaviour works 
