### PR TITLE
Feat/add required to sim color detector

### DIFF
--- a/igvc_gazebo/launch/sim_detector.launch
+++ b/igvc_gazebo/launch/sim_detector.launch
@@ -2,7 +2,7 @@
 
 <launch>
 
-  <node name="sim_color_detector" pkg="igvc_gazebo" type="sim_color_detector" output="screen">
+  <node name="sim_color_detector" pkg="igvc_gazebo" type="sim_color_detector" output="screen" required="true">
       <!-- names of cameras to subscribe to -->
       <rosparam param="camera_names">["/cam/center", "/cam/left", "/cam/right"]</rosparam>
       <rosparam param="semantic_topic_prefix">["/cam/center", "/cam/left", "/cam/right"]</rosparam>


### PR DESCRIPTION
This PR sets sim_color_detector to required="true"

Fixes #755 

# Testing steps (If relevant)
1. Run sim_detector.launch
2. Run rosnode kill on sim_color_detector node.

Expectation: The whole stack dies when the sime_color_detector node dies.

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
