### PR TITLE
Remove respawn=true so that simulations run

### DIFF
--- a/igvc_gazebo/launch/simulation.launch
+++ b/igvc_gazebo/launch/simulation.launch
@@ -59,7 +59,7 @@
         <param name="mag_field_variance" value = "0.000001"/>
     </node>
 
-    <node name="ground_truth_to_rpy" pkg="igvc_utils" type="quaternion_to_rpy" respawn="true" output="screen" required="true">
+    <node name="ground_truth_to_rpy" pkg="igvc_utils" type="quaternion_to_rpy" output="screen" required="true">
         <param name="topics/quaternion" value="/ground_truth"/>
         <param name="topics/rpy" value="/ground_truth_rpy"/>
         <param name="message_type" value="odometry"/>

--- a/igvc_gazebo/launch/simulation_low.launch
+++ b/igvc_gazebo/launch/simulation_low.launch
@@ -53,7 +53,7 @@
         <param name="ground_truth_pub_topic" value="/ground_truth"/>
     </node>
 
-    <node name="ground_truth_to_rpy" pkg="igvc_utils" type="quaternion_to_rpy" respawn="true" output="screen" required="true">
+    <node name="ground_truth_to_rpy" pkg="igvc_utils" type="quaternion_to_rpy" output="screen" required="true">
         <param name="topics/quaternion" value="/ground_truth"/>
         <param name="topics/rpy" value="/ground_truth_rpy"/>
         <param name="message_type" value="odometry"/>

--- a/igvc_utils/launch/imu_to_rpy.launch
+++ b/igvc_utils/launch/imu_to_rpy.launch
@@ -1,11 +1,11 @@
 <launch>
-  <node pkg="igvc_utils" type="quaternion_to_rpy" name="imu_top_to_rpy" respawn="true" output="screen" required="true">
+  <node pkg="igvc_utils" type="quaternion_to_rpy" name="imu_top_to_rpy" output="screen" required="true">
     <param name="topics/quaternion" value="/magnetometer"/>
     <param name="topics/rpy" value="/magnetometer_rpy"/>
     <param name="message_type" value="imu"/>
   </node>
 
-  <node pkg="igvc_utils" type="quaternion_to_rpy" name="imu_bottom_to_rpy" respawn="true" output="screen" required="true">
+  <node pkg="igvc_utils" type="quaternion_to_rpy" name="imu_bottom_to_rpy" output="screen" required="true">
     <param name="topics/quaternion" value="/imu"/>
     <param name="topics/rpy" value="/imu_rpy"/>
     <param name="message_type" value="imu"/>


### PR DESCRIPTION
# Description
Fixes a mistake that was previously merged in. This PR removes the respawn=true tag from several nodes so that both simulation.launch and simulation_low.launch actually work. 

This PR does the following:
- Fixes the simulations so they launch.

Fixes #821 

# Testing steps (If relevant)
## Test Case 1
1. run `catkin_make`
2. run `roslaunch igvc_gazebo autonav_low.launch`
3. check that gazebo opens
4. close gazebo and run `roslaunch igvc_gazebo qualification.launch`
5. check that gazebo opens

Expectation: Both the regular and the low simulations open and run normally.

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
