### PR TITLE
Splits control node into a c++ class and header

### DIFF
--- a/igvc_gazebo/nodes/control/CMakeLists.txt
+++ b/igvc_gazebo/nodes/control/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(control main.cpp)
+add_executable(control control.cpp)
 add_dependencies(control ${catkin_EXPORTED_TARGETS})
 target_link_libraries(control ${catkin_LIBRARIES})
 

--- a/igvc_gazebo/nodes/control/control.h
+++ b/igvc_gazebo/nodes/control/control.h
@@ -1,0 +1,23 @@
+#ifndef Control_h
+#define Control_h
+
+#include <igvc_msgs/velocity_pair.h>
+#include <sensor_msgs/JointState.h>
+
+
+class Control
+{
+
+public:
+	Control();
+private:
+	double speed_set_point_left;
+	double speed_set_point_right;
+	double speed_measured_left;
+	double speed_measured_right;
+	double wheel_radius;
+	void speedCallback(const igvc_msgs::velocity_pair::ConstPtr &msg);
+	void jointStateCallback(const sensor_msgs::JointStateConstPtr &msg);
+	
+};
+#endif


### PR DESCRIPTION
Makes the control node a c++ class with header

Fixes #738 

# Testing steps (If relevant)
## Test Case 1
1. Test original node
2. Test new node on this branch

Expectation: Everything still works fine

# Self Checklist
- [ ] I have formatted my code using `make format`
- [ ] I have tested that the new behaviour works 
