### PR TITLE
Bug/circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,9 @@ jobs:
       - <<: *load_src_cache
       - checkout:
           path: ~/catkin_ws/src/igvc-software
+      - <<: *install_deps
       - <<: *checkout_submodules
       - <<: *save_src_cache
-      - <<: *install_deps
       - <<: *load_compile_cache
       - run: source /opt/ros/noetic/setup.sh && catkin_make -j2 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
       - <<: *save_compile_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,9 @@ jobs:
       - <<: *load_src_cache
       - checkout:
           path: ~/catkin_ws/src/igvc-software
-      - <<: *install_deps
       - <<: *checkout_submodules
       - <<: *save_src_cache
+      - <<: *install_deps
       - <<: *load_compile_cache
       - run: source /opt/ros/noetic/setup.sh && catkin_make -j2 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
       - <<: *save_compile_cache

--- a/igvc_gazebo/package.xml
+++ b/igvc_gazebo/package.xml
@@ -20,6 +20,7 @@
   <depend>nav_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>tf</depend>
+  <depend>geographiclib</depend>
   <depend>robot_localization</depend>
 
   <build_depend>pcl_conversions</build_depend>

--- a/igvc_navigation/package.xml
+++ b/igvc_navigation/package.xml
@@ -44,6 +44,7 @@
   <depend>tf2_eigen</depend>
   <depend>image_transport</depend>
   <depend>image_geometry</depend>
+  <depend>geographiclib</depend>
   <depend>robot_localization</depend>
   <depend>pcl_conversions</depend>
   <depend>igvc_msgs</depend>

--- a/igvc_perception/package.xml
+++ b/igvc_perception/package.xml
@@ -60,6 +60,7 @@
   <exec_depend>cv_bridge</exec_depend>
   <exec_depend>pcl_conversions</exec_depend>
   <exec_depend>image_geometry</exec_depend>
+  <exec_depend>geographiclib</exec_depend>
   <exec_depend>robot_localization</exec_depend>
   <exec_depend>pluginlib</exec_depend>
   <exec_depend>python-pytorch-pip</exec_depend>

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -10,7 +10,6 @@ if [ ! -d "/usr/local/include/kindr/" ]; then
     rm -rf kindr
 fi
 
-apt-get update --fix-missing
 rosdep update
 rosdep install -iy --from-paths ../../src --skip-keys='kindr serial'
 pip3 install --no-cache-dir torch torchvision

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -10,5 +10,6 @@ if [ ! -d "/usr/local/include/kindr/" ]; then
     rm -rf kindr
 fi
 
+rosdep update
 rosdep install -iy --from-paths ../../src --skip-keys='kindr serial'
 pip3 install --no-cache-dir torch torchvision

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -10,6 +10,7 @@ if [ ! -d "/usr/local/include/kindr/" ]; then
     rm -rf kindr
 fi
 
+apt-get update --fix-missing
 rosdep update
 rosdep install -iy --from-paths ../../src --skip-keys='kindr serial'
 pip3 install --no-cache-dir torch torchvision


### PR DESCRIPTION
# Description
Fixes the circle ci pipeline. Able to add a workaround for a bug with robot_localization since it only pulls in GeographicLib as a build dependency. Needed to add GeographicLib since it is also included in some of the header files in robot_localization.

This PR does the following:
- Fixes the circle ci pipeline.

# Testing
1. See if Circle CI build passes. See [here](https://app.circleci.com/pipelines/github/RoboJackets/igvc-software/474/workflows/a4fb7c6a-5896-4a81-b6c6-1d7a9dc5ddc6)

Expectation: Circle CI build passes

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
