### PR TITLE
Bug/camera names

### DIFF
--- a/igvc_platform/launch/camera.launch
+++ b/igvc_platform/launch/camera.launch
@@ -34,7 +34,7 @@
 		    <param name="pixel_format" type="string" value="yuyv" />
 		    <param name="camera_frame_id" type="string" value="cam/left" />
 	 	    <param name="camera_info_url" type="string" value="file://$(find igvc_sandbox)/camera_config/usb_cam_left.yaml" />
-		    <param name="camera_name" type="string" value="cam/right/raw" />
+		    <param name="camera_name" type="string" value="cam/left/raw" />
 			<param name="framerate" value="30" />
 		</node>
 	</group>

--- a/igvc_platform/launch/camera.launch
+++ b/igvc_platform/launch/camera.launch
@@ -22,7 +22,7 @@
 		    <param name="pixel_format" type="string" value="yuyv" />
 		    <param name="camera_frame_id" type="string" value="cam/right" />
 	 	    <param name="camera_info_url" type="string" value="file://$(find igvc_sandbox)/camera_config/usb_cam_right.yaml" />
-		    <param name="camera_name" type="string" value="cam/center/raw" />
+		    <param name="camera_name" type="string" value="cam/right/raw" />
 			<param name="framerate" value="30" />
 		</node>
 	</group>
@@ -34,7 +34,7 @@
 		    <param name="pixel_format" type="string" value="yuyv" />
 		    <param name="camera_frame_id" type="string" value="cam/left" />
 	 	    <param name="camera_info_url" type="string" value="file://$(find igvc_sandbox)/camera_config/usb_cam_left.yaml" />
-		    <param name="camera_name" type="string" value="cam/center/raw" />
+		    <param name="camera_name" type="string" value="cam/right/raw" />
 			<param name="framerate" value="30" />
 		</node>
 	</group>


### PR DESCRIPTION
# Description

camera.launch had multiple cameras named as cam/center

This PR does the following:
- Fixes left and right camera names in launch file

Fixes #856 

Expectation: camera publish names on launch should be "cam/right/raw" and "cam/left/raw"

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
