### PR TITLE
Ground truth

### DIFF
--- a/igvc_gazebo/nodes/ground_truth/CMakeLists.txt
+++ b/igvc_gazebo/nodes/ground_truth/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(ground_truth_republisher main.cpp)
+add_executable(ground_truth_republisher ground_truth_republisher.cpp)
 add_dependencies(ground_truth_republisher ${catkin_EXPORTED_TARGETS})
 target_link_libraries(ground_truth_republisher ${catkin_LIBRARIES})
 

--- a/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.cpp
+++ b/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.cpp
@@ -17,9 +17,9 @@ GroundTruthRepublisher::GroundTruthRepublisher()
 	assertions::param(pNh, "longitude", longitude, -84.405001);
 	assertions::param(pNh, "latitude", latitude, 33.774497);
 
-	ros::Subscriber ground_truth = nh.subscribe<nav_msgs::Odometry>(ground_truth_topic, 10, groundTruthCallback);
+	ros::Subscriber ground_truth = nh.subscribe<nav_msgs::Odometry>(ground_truth_topic, 10, &GroundTruthRepublisher::groundTruthCallback, this);
 
-	ros::Subscriber estimate_sub = nh.subscribe<nav_msgs::Odometry>("/odometry/filtered", 1, odomCallback);
+	ros::Subscriber estimate_sub = nh.subscribe<nav_msgs::Odometry>("/odometry/filtered", 1, &GroundTruthRepubisher::odomCallback, this);
 	g_ground_truth_pub = nh.advertise<nav_msgs::Odometry>(pub_topic, 1);
 
 	double utm_x, utm_y;
@@ -30,7 +30,7 @@ GroundTruthRepublisher::GroundTruthRepublisher()
 		tf::Vector3(utm_x - g_og_pose.pose.pose.position.x, utm_y - g_og_pose.pose.pose.position.y, 0.0));
 	utm_to_odom.setRotation(tf::createQuaternionFromYaw(M_PI));
 
-	ros::Timer utm_timer = nh.createTimer(ros::Duration(1.0), boost::bind(utm_callback, _1, utm_to_odom.inverse()));
+	ros::Timer utm_timer = nh.createTimer(ros::Duration(1.0), boost::bind(&GroundTruthRepublisher::utm_callback, _1, utm_to_odom.inverse()));
 }
 
 void GroundTruthRepublisher::odomCallback(const nav_msgs::Odometry::ConstPtr& msg)

--- a/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.cpp
+++ b/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.cpp
@@ -31,7 +31,6 @@ GroundTruthRepublisher::GroundTruthRepublisher()
 	utm_to_odom.setRotation(tf::createQuaternionFromYaw(M_PI));
 
 	ros::Timer utm_timer = nh.createTimer(ros::Duration(1.0), boost::bind(utm_callback, _1, utm_to_odom.inverse()));
-	ros::spin();
 }
 
 void GroundTruthRepublisher::odomCallback(const nav_msgs::Odometry::ConstPtr& msg)
@@ -116,5 +115,11 @@ void GroundTruthRepublisher::utm_callback(const ros::TimerEvent& event, const tf
     }
     br.sendTransform(tf::StampedTransform(odom_to_utm, event.current_real, "odom", "utm"));
   }
+}
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "ground_truth_republisher");
+  GroundTruthRepublisher ground_truth_republisher;
+  ros::spin();
 }
 

--- a/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.cpp
+++ b/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.cpp
@@ -19,7 +19,7 @@ GroundTruthRepublisher::GroundTruthRepublisher()
 
 	ros::Subscriber ground_truth = nh.subscribe<nav_msgs::Odometry>(ground_truth_topic, 10, &GroundTruthRepublisher::groundTruthCallback, this);
 
-	ros::Subscriber estimate_sub = nh.subscribe<nav_msgs::Odometry>("/odometry/filtered", 1, &GroundTruthRepubisher::odomCallback, this);
+	ros::Subscriber estimate_sub = nh.subscribe<nav_msgs::Odometry>("/odometry/filtered", 1, &GroundTruthRepublisher::odomCallback, this);
 	g_ground_truth_pub = nh.advertise<nav_msgs::Odometry>(pub_topic, 1);
 
 	double utm_x, utm_y;
@@ -30,7 +30,7 @@ GroundTruthRepublisher::GroundTruthRepublisher()
 		tf::Vector3(utm_x - g_og_pose.pose.pose.position.x, utm_y - g_og_pose.pose.pose.position.y, 0.0));
 	utm_to_odom.setRotation(tf::createQuaternionFromYaw(M_PI));
 
-	ros::Timer utm_timer = nh.createTimer(ros::Duration(1.0), boost::bind(&GroundTruthRepublisher::utm_callback, _1, utm_to_odom.inverse()));
+	ros::Timer utm_timer = nh.createTimer(ros::Duration(1.0), boost::bind(utm_callback, _1, utm_to_odom.inverse()));
 }
 
 void GroundTruthRepublisher::odomCallback(const nav_msgs::Odometry::ConstPtr& msg)

--- a/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.cpp
+++ b/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.cpp
@@ -5,40 +5,43 @@
 
 GroundTruthRepublisher::GroundTruthRepublisher()
 {
-	ros::NodeHandle nh;
-	ros::NodeHandle pNh("~");
+  ros::NodeHandle nh;
+  ros::NodeHandle pNh("~");
 
-	std::string ground_truth_topic, estimate_topic, pub_topic, diff_topic;
+  std::string ground_truth_topic, estimate_topic, pub_topic, diff_topic;
 
-	assertions::param(pNh, "ground_truth_sub_topic", ground_truth_topic, std::string("/ground_truth/state_raw"));
-	assertions::param(pNh, "ground_truth_pub_topic", pub_topic, std::string("/ground_truth"));
+  assertions::param(pNh, "ground_truth_sub_topic", ground_truth_topic, std::string("/ground_truth/state_raw"));
+  assertions::param(pNh, "ground_truth_pub_topic", pub_topic, std::string("/ground_truth"));
 
-	double longitude, latitude;
-	assertions::param(pNh, "longitude", longitude, -84.405001);
-	assertions::param(pNh, "latitude", latitude, 33.774497);
+  double longitude, latitude;
+  assertions::param(pNh, "longitude", longitude, -84.405001);
+  assertions::param(pNh, "latitude", latitude, 33.774497);
 
-	ros::Subscriber ground_truth = nh.subscribe<nav_msgs::Odometry>(ground_truth_topic, 10, &GroundTruthRepublisher::groundTruthCallback, this);
+  ros::Subscriber ground_truth =
+      nh.subscribe<nav_msgs::Odometry>(ground_truth_topic, 10, &GroundTruthRepublisher::groundTruthCallback, this);
 
-	ros::Subscriber estimate_sub = nh.subscribe<nav_msgs::Odometry>("/odometry/filtered", 1, &GroundTruthRepublisher::odomCallback, this);
-	g_ground_truth_pub = nh.advertise<nav_msgs::Odometry>(pub_topic, 1);
+  ros::Subscriber estimate_sub =
+      nh.subscribe<nav_msgs::Odometry>("/odometry/filtered", 1, &GroundTruthRepublisher::odomCallback, this);
+  g_ground_truth_pub = nh.advertise<nav_msgs::Odometry>(pub_topic, 1);
 
-	double utm_x, utm_y;
-	RobotLocalization::NavsatConversions::UTM(latitude, longitude, &utm_x, &utm_y);
+  double utm_x, utm_y;
+  RobotLocalization::NavsatConversions::UTM(latitude, longitude, &utm_x, &utm_y);
 
-	tf::Transform utm_to_odom;
-	utm_to_odom.setOrigin(
-    tf::Vector3(utm_x - g_og_pose.pose.pose.position.x, utm_y - g_og_pose.pose.pose.position.y, 0.0));
-	utm_to_odom.setRotation(tf::createQuaternionFromYaw(M_PI));
+  tf::Transform utm_to_odom;
+  utm_to_odom.setOrigin(
+      tf::Vector3(utm_x - g_og_pose.pose.pose.position.x, utm_y - g_og_pose.pose.pose.position.y, 0.0));
+  utm_to_odom.setRotation(tf::createQuaternionFromYaw(M_PI));
 
-	ros::Timer utm_timer = nh.createTimer(ros::Duration(1.0), boost::bind(&GroundTruthRepublisher::utm_callback, this, _1, utm_to_odom.inverse()));
+  ros::Timer utm_timer = nh.createTimer(
+      ros::Duration(1.0), boost::bind(&GroundTruthRepublisher::utm_callback, this, _1, utm_to_odom.inverse()));
 }
 
-void GroundTruthRepublisher::odomCallback(const nav_msgs::Odometry::ConstPtr& msg)
+void GroundTruthRepublisher::odomCallback(const nav_msgs::Odometry::ConstPtr &msg)
 {
   g_last_estimate = msg->header.stamp;
 }
 
-void GroundTruthRepublisher::groundTruthCallback(const nav_msgs::Odometry::ConstPtr& msg)
+void GroundTruthRepublisher::groundTruthCallback(const nav_msgs::Odometry::ConstPtr &msg)
 {
   // get the starting location as the origin
   if (g_og_pose.header.stamp.toSec() == 0)
@@ -74,8 +77,9 @@ void GroundTruthRepublisher::groundTruthCallback(const nav_msgs::Odometry::Const
     // publish odom message
     g_ground_truth_pub.publish(result);
 
-    // publish transform for tf if there has not been a update from the localization node in the last second
-    // since it also publishes the same transform
+    // publish transform for tf if there has not been a update from the
+    // localization node in the last second since it also publishes the same
+    // transform
     if (std::abs(msg->header.stamp.toSec() - g_last_estimate.toSec()) > 1.0)
     {
       static tf::TransformBroadcaster br;
@@ -87,7 +91,7 @@ void GroundTruthRepublisher::groundTruthCallback(const nav_msgs::Odometry::Const
   }
 }
 
-void GroundTruthRepublisher::utm_callback(const ros::TimerEvent& event, const tf::Transform& odom_to_utm)
+void GroundTruthRepublisher::utm_callback(const ros::TimerEvent &event, const tf::Transform &odom_to_utm)
 {
   static tf::TransformBroadcaster br;
   static tf::TransformListener tf_listener;
@@ -101,7 +105,7 @@ void GroundTruthRepublisher::utm_callback(const ros::TimerEvent& event, const tf
     {
       tf_listener.lookupTransform("odom", "utm", ros::Time(0), transform);
     }
-    catch (const tf::TransformException& ex)
+    catch (const tf::TransformException &ex)
     {
       found = false;
     }
@@ -109,7 +113,8 @@ void GroundTruthRepublisher::utm_callback(const ros::TimerEvent& event, const tf
     if (found && transform.getRotation() != odom_to_utm.getRotation() &&
         transform.getOrigin() != odom_to_utm.getOrigin())
     {
-      ROS_WARN_STREAM("Anther odom -> utm tf broadcast detected. Disabling ground_truth odom -> utm tf broadcast.");
+      ROS_WARN_STREAM("Anther odom -> utm tf broadcast detected. Disabling "
+                      "ground_truth odom -> utm tf broadcast.");
       enabled = false;
       return;
     }
@@ -117,7 +122,7 @@ void GroundTruthRepublisher::utm_callback(const ros::TimerEvent& event, const tf
   }
 }
 
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
   ros::init(argc, argv, "ground_truth_republisher");
   GroundTruthRepublisher ground_truth_republisher = GroundTruthRepublisher();

--- a/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.cpp
+++ b/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.cpp
@@ -1,6 +1,4 @@
 #include "ground_truth_republisher.h"
-#include <mutex>
-#include <parameter_assertions/assertions.h>
 #include <ros/ros.h>
 
 GroundTruthRepublisher::GroundTruthRepublisher()
@@ -113,8 +111,7 @@ void GroundTruthRepublisher::utm_callback(const ros::TimerEvent &event, const tf
     if (found && transform.getRotation() != odom_to_utm.getRotation() &&
         transform.getOrigin() != odom_to_utm.getOrigin())
     {
-      ROS_WARN_STREAM("Anther odom -> utm tf broadcast detected. Disabling "
-                      "ground_truth odom -> utm tf broadcast.");
+      ROS_WARN_STREAM("Another odom -> utm tf broadcast detected. Disabling ground_truth odom -> utm tf broadcast.");
       enabled = false;
       return;
     }

--- a/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.cpp
+++ b/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.cpp
@@ -1,7 +1,7 @@
+#include "ground_truth_republisher.h"
 #include <mutex>
 #include <parameter_assertions/assertions.h>
 #include <ros/ros.h>
-#include "ground_truth_republisher.h"
 
 GroundTruthRepublisher::GroundTruthRepublisher()
 {
@@ -31,12 +31,12 @@ GroundTruthRepublisher::GroundTruthRepublisher()
 	utm_to_odom.setRotation(tf::createQuaternionFromYaw(M_PI));
 
 	ros::Timer utm_timer = nh.createTimer(ros::Duration(1.0), boost::bind(&GroundTruthRepublisher::utm_callback, this, _1, utm_to_odom.inverse()));
-}
+};
 
 void GroundTruthRepublisher::odomCallback(const nav_msgs::Odometry::ConstPtr& msg)
 {
   g_last_estimate = msg->header.stamp;
-}
+};
 
 void GroundTruthRepublisher::groundTruthCallback(const nav_msgs::Odometry::ConstPtr& msg)
 {
@@ -85,7 +85,7 @@ void GroundTruthRepublisher::groundTruthCallback(const nav_msgs::Odometry::Const
       tf::Transform utm_to_odom;
     }
   }
-}
+};
 
 void GroundTruthRepublisher::utm_callback(const ros::TimerEvent& event, const tf::Transform& odom_to_utm)
 {
@@ -115,7 +115,8 @@ void GroundTruthRepublisher::utm_callback(const ros::TimerEvent& event, const tf
     }
     br.sendTransform(tf::StampedTransform(odom_to_utm, event.current_real, "odom", "utm"));
   }
-}
+};
+
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "ground_truth_republisher");

--- a/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.cpp
+++ b/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.cpp
@@ -30,7 +30,7 @@ GroundTruthRepublisher::GroundTruthRepublisher()
 		tf::Vector3(utm_x - g_og_pose.pose.pose.position.x, utm_y - g_og_pose.pose.pose.position.y, 0.0));
 	utm_to_odom.setRotation(tf::createQuaternionFromYaw(M_PI));
 
-	ros::Timer utm_timer = nh.createTimer(ros::Duration(1.0), boost::bind(utm_callback, _1, utm_to_odom.inverse()));
+	ros::Timer utm_timer = nh.createTimer(ros::Duration(1.0), boost::bind(&GroundTruthRepublisher::utm_callback, this, _1, utm_to_odom.inverse()));
 }
 
 void GroundTruthRepublisher::odomCallback(const nav_msgs::Odometry::ConstPtr& msg)

--- a/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.cpp
+++ b/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.cpp
@@ -27,16 +27,16 @@ GroundTruthRepublisher::GroundTruthRepublisher()
 
 	tf::Transform utm_to_odom;
 	utm_to_odom.setOrigin(
-		tf::Vector3(utm_x - g_og_pose.pose.pose.position.x, utm_y - g_og_pose.pose.pose.position.y, 0.0));
+    tf::Vector3(utm_x - g_og_pose.pose.pose.position.x, utm_y - g_og_pose.pose.pose.position.y, 0.0));
 	utm_to_odom.setRotation(tf::createQuaternionFromYaw(M_PI));
 
 	ros::Timer utm_timer = nh.createTimer(ros::Duration(1.0), boost::bind(&GroundTruthRepublisher::utm_callback, this, _1, utm_to_odom.inverse()));
-};
+}
 
 void GroundTruthRepublisher::odomCallback(const nav_msgs::Odometry::ConstPtr& msg)
 {
   g_last_estimate = msg->header.stamp;
-};
+}
 
 void GroundTruthRepublisher::groundTruthCallback(const nav_msgs::Odometry::ConstPtr& msg)
 {
@@ -85,7 +85,7 @@ void GroundTruthRepublisher::groundTruthCallback(const nav_msgs::Odometry::Const
       tf::Transform utm_to_odom;
     }
   }
-};
+}
 
 void GroundTruthRepublisher::utm_callback(const ros::TimerEvent& event, const tf::Transform& odom_to_utm)
 {
@@ -115,12 +115,11 @@ void GroundTruthRepublisher::utm_callback(const ros::TimerEvent& event, const tf
     }
     br.sendTransform(tf::StampedTransform(odom_to_utm, event.current_real, "odom", "utm"));
   }
-};
+}
 
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "ground_truth_republisher");
-  GroundTruthRepublisher ground_truth_republisher;
+  GroundTruthRepublisher ground_truth_republisher = GroundTruthRepublisher();
   ros::spin();
 }
-

--- a/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.cpp
+++ b/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.cpp
@@ -1,24 +1,45 @@
-#include <geometry_msgs/Vector3.h>
-#include <nav_msgs/Odometry.h>
-#include <parameter_assertions/assertions.h>
-#include <robot_localization/navsat_conversions.h>
-#include <ros/ros.h>
-#include <tf/transform_broadcaster.h>
-#include <tf/transform_datatypes.h>
-#include <tf/transform_listener.h>
 #include <mutex>
+#include <parameter_assertions/assertions.h>
+#include <ros/ros.h>
+#include "ground_truth_republisher.h"
 
-ros::Publisher g_ground_truth_pub;
-// TODO make this a minimal object
-nav_msgs::Odometry g_og_pose;
-ros::Time g_last_estimate;
+GroundTruthRepublisher::GroundTruthRepublisher()
+{
+	ros::NodeHandle nh;
+	ros::NodeHandle pNh("~");
 
-void odomCallback(const nav_msgs::Odometry::ConstPtr& msg)
+	std::string ground_truth_topic, estimate_topic, pub_topic, diff_topic;
+
+	assertions::param(pNh, "ground_truth_sub_topic", ground_truth_topic, std::string("/ground_truth/state_raw"));
+	assertions::param(pNh, "ground_truth_pub_topic", pub_topic, std::string("/ground_truth"));
+
+	double longitude, latitude;
+	assertions::param(pNh, "longitude", longitude, -84.405001);
+	assertions::param(pNh, "latitude", latitude, 33.774497);
+
+	ros::Subscriber ground_truth = nh.subscribe<nav_msgs::Odometry>(ground_truth_topic, 10, groundTruthCallback);
+
+	ros::Subscriber estimate_sub = nh.subscribe<nav_msgs::Odometry>("/odometry/filtered", 1, odomCallback);
+	g_ground_truth_pub = nh.advertise<nav_msgs::Odometry>(pub_topic, 1);
+
+	double utm_x, utm_y;
+	RobotLocalization::NavsatConversions::UTM(latitude, longitude, &utm_x, &utm_y);
+
+	tf::Transform utm_to_odom;
+	utm_to_odom.setOrigin(
+		tf::Vector3(utm_x - g_og_pose.pose.pose.position.x, utm_y - g_og_pose.pose.pose.position.y, 0.0));
+	utm_to_odom.setRotation(tf::createQuaternionFromYaw(M_PI));
+
+	ros::Timer utm_timer = nh.createTimer(ros::Duration(1.0), boost::bind(utm_callback, _1, utm_to_odom.inverse()));
+	ros::spin();
+}
+
+void GroundTruthRepublisher::odomCallback(const nav_msgs::Odometry::ConstPtr& msg)
 {
   g_last_estimate = msg->header.stamp;
 }
 
-void groundTruthCallback(const nav_msgs::Odometry::ConstPtr& msg)
+void GroundTruthRepublisher::groundTruthCallback(const nav_msgs::Odometry::ConstPtr& msg)
 {
   // get the starting location as the origin
   if (g_og_pose.header.stamp.toSec() == 0)
@@ -67,7 +88,7 @@ void groundTruthCallback(const nav_msgs::Odometry::ConstPtr& msg)
   }
 }
 
-void utm_callback(const ros::TimerEvent& event, const tf::Transform& odom_to_utm)
+void GroundTruthRepublisher::utm_callback(const ros::TimerEvent& event, const tf::Transform& odom_to_utm)
 {
   static tf::TransformBroadcaster br;
   static tf::TransformListener tf_listener;
@@ -97,35 +118,3 @@ void utm_callback(const ros::TimerEvent& event, const tf::Transform& odom_to_utm
   }
 }
 
-int main(int argc, char** argv)
-{
-  ros::init(argc, argv, "ground_truth_republisher");
-
-  ros::NodeHandle nh;
-  ros::NodeHandle pNh("~");
-
-  std::string ground_truth_topic, estimate_topic, pub_topic, diff_topic;
-
-  assertions::param(pNh, "ground_truth_sub_topic", ground_truth_topic, std::string("/ground_truth/state_raw"));
-  assertions::param(pNh, "ground_truth_pub_topic", pub_topic, std::string("/ground_truth"));
-
-  double longitude, latitude;
-  assertions::param(pNh, "longitude", longitude, -84.405001);
-  assertions::param(pNh, "latitude", latitude, 33.774497);
-
-  ros::Subscriber ground_truth = nh.subscribe<nav_msgs::Odometry>(ground_truth_topic, 10, groundTruthCallback);
-
-  ros::Subscriber estimate_sub = nh.subscribe<nav_msgs::Odometry>("/odometry/filtered", 1, odomCallback);
-  g_ground_truth_pub = nh.advertise<nav_msgs::Odometry>(pub_topic, 1);
-
-  double utm_x, utm_y;
-  RobotLocalization::NavsatConversions::UTM(latitude, longitude, &utm_x, &utm_y);
-
-  tf::Transform utm_to_odom;
-  utm_to_odom.setOrigin(
-      tf::Vector3(utm_x - g_og_pose.pose.pose.position.x, utm_y - g_og_pose.pose.pose.position.y, 0.0));
-  utm_to_odom.setRotation(tf::createQuaternionFromYaw(M_PI));
-
-  ros::Timer utm_timer = nh.createTimer(ros::Duration(1.0), boost::bind(utm_callback, _1, utm_to_odom.inverse()));
-  ros::spin();
-}

--- a/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.h
+++ b/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.h
@@ -1,5 +1,5 @@
-#ifndef GROUND_TRUTH_REPUBLISHER_HPP_
-#define GROUND_TRUTH_REPUBLISHER_HPP_HPP_
+#ifndef GROUND_TRUTH_REPUBLISHER_H
+#define GROUND_TRUTH_REPUBLISHER_H
 
 #include <rclcpp/rclcpp.hpp>
 #include <geometry_msgs/Vector3.h>

--- a/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.h
+++ b/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.h
@@ -11,16 +11,16 @@
 class GroundTruthRepublisher
 {
 public:
-	GroundTruthRepublisher();
+  GroundTruthRepublisher();
 
 private:
-	ros::Publisher g_ground_truth_pub;
-	nav_msgs::Odometry g_og_pose;
-	ros::Time g_last_estimate;
-	
-	void odomCallback(const nav_msgs::Odometry::ConstPtr& msg);
-	void groundTruthCallback(const nav_msgs::Odometry::ConstPtr& msg);
-	void utm_callback(const ros::TimerEvent& event, const tf::Transform& odom_to_utm);
+  ros::Publisher g_ground_truth_pub;
+  nav_msgs::Odometry g_og_pose;
+  ros::Time g_last_estimate;
+
+  void odomCallback(const nav_msgs::Odometry::ConstPtr& msg);
+  void groundTruthCallback(const nav_msgs::Odometry::ConstPtr& msg);
+  void utm_callback(const ros::TimerEvent& event, const tf::Transform& odom_to_utm);
 };
 
 #endif

--- a/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.h
+++ b/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.h
@@ -1,7 +1,6 @@
 #ifndef GROUND_TRUTH_REPUBLISHER_H
 #define GROUND_TRUTH_REPUBLISHER_H
 
-#include <rclcpp/rclcpp.hpp>
 #include <geometry_msgs/Vector3.h>
 #include <nav_msgs/Odometry.h>
 #include <robot_localization/navsat_conversions.h>

--- a/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.h
+++ b/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.h
@@ -1,0 +1,27 @@
+#ifndef GROUND_TRUTH_REPUBLISHER_HPP_
+#define GROUND_TRUTH_REPUBLISHER_HPP_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/Vector3.h>
+#include <nav_msgs/Odometry.h>
+#include <robot_localization/navsat_conversions.h>
+#include <tf/transform_broadcaster.h>
+#include <tf/transform_datatypes.h>
+#include <tf/transform_listener.h>
+
+class GroundTruthRepublisher
+{
+public:
+	GroundTruthRepublisher();
+private:
+	ros::Publisher g_ground_truth_pub;
+	nav_msgs::Odometry g_og_pose;
+	ros::Time g_last_estimate;
+	
+	void odomCallback(const nav_msgs::Odometry::ConstPtr& msg);
+	void groundTruthCallback(const nav_msgs::Odometry::ConstPtr& msg);
+	void utm_callback(const ros::TimerEvent& event, const tf::Transform& odom_to_utm);
+	
+};
+
+#endif

--- a/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.h
+++ b/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.h
@@ -12,6 +12,7 @@ class GroundTruthRepublisher
 {
 public:
 	GroundTruthRepublisher();
+
 private:
 	ros::Publisher g_ground_truth_pub;
 	nav_msgs::Odometry g_og_pose;
@@ -20,7 +21,6 @@ private:
 	void odomCallback(const nav_msgs::Odometry::ConstPtr& msg);
 	void groundTruthCallback(const nav_msgs::Odometry::ConstPtr& msg);
 	void utm_callback(const ros::TimerEvent& event, const tf::Transform& odom_to_utm);
-	
 };
 
 #endif

--- a/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.h
+++ b/igvc_gazebo/nodes/ground_truth/ground_truth_republisher.h
@@ -3,6 +3,7 @@
 
 #include <geometry_msgs/Vector3.h>
 #include <nav_msgs/Odometry.h>
+#include <parameter_assertions/assertions.h>
 #include <robot_localization/navsat_conversions.h>
 #include <tf/transform_broadcaster.h>
 #include <tf/transform_datatypes.h>


### PR DESCRIPTION
# Description

Takes the main.cpp file for the ground_truth node and splits it into a .cpp and header file for a ground truth republished node.

This PR does the following:
- Creates a header file for the ground truth node
- Creates the ground truth node

Fixes #739 

# Testing steps (If relevant)
1. Ground truth republisher still works properly

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behavior works 
