### PR TITLE
Swervi Wheel Shaking Bug

### DIFF
--- a/igvc_gazebo/launch/swervi_control.launch
+++ b/igvc_gazebo/launch/swervi_control.launch
@@ -28,6 +28,7 @@
       <param name="wheel_radius" value="0.3429"/>
       <param name="max_effort" value="8.0"/>
       <param name="rate" value="60.0"/>
+      <param name="alpha" value="0.5"/>
   </node>
 
 

--- a/igvc_gazebo/nodes/swerve_control/swerve_control.cpp
+++ b/igvc_gazebo/nodes/swerve_control/swerve_control.cpp
@@ -50,6 +50,8 @@ SwerveControl::SwerveControl() : pNh{ "~" }
   assertions::param(pNh, "max_effort", max_effort, 4.0);
   assertions::param(pNh, "rate", rate_var, 60.0);
 
+  assertions::param(pNh, "alpha", alpha, 0.5);
+
   // joint names
   joint_names = { "fl_wheel_axle", "fr_wheel_axle", "bl_wheel_axle", "br_wheel_axle",
                   "fl_swivel_rev", "fr_swivel_rev", "bl_swivel_rev", "br_swivel_rev" };
@@ -101,9 +103,11 @@ void SwerveControl::ControlLoop()
     for (size_t i = 0; i < motors_end; ++i)
     {
       double error = motors[i].set_point - motors[i].measured;
-      double dError = (error - motors[i].last_error) / dt;
-      motors[i].error_accum += error;
-      motors[i].last_error = error;
+      double filtered_error = alpha * error + (1 - alpha) * motors[i].last_error;
+      double dError = (dt == 0) ? 0 : (filtered_error - motors[i].last_error) / dt;
+
+      motors[i].error_accum += error * dt;
+      motors[i].last_error = filtered_error;
       motors[i].effort += motors[i].P * error + motors[i].D * dError + motors[i].I * motors[i].error_accum;
       motors[i].effort = std::min(max_effort, std::max(-max_effort, motors[i].effort));
       std_msgs::Float64 effort_msg;
@@ -188,7 +192,7 @@ void SwerveControl::jointStateCallback(const sensor_msgs::JointStateConstPtr &ms
     if (iter != msg->name.end())
     {
       auto index = std::distance(msg->name.begin(), iter);
-      motors[i].measured = (msg->velocity[index]) * (wheel_radius);
+      motors[i].measured = msg->velocity[index] * wheel_radius;
     }
   }
 

--- a/igvc_gazebo/nodes/swerve_control/swerve_control.h
+++ b/igvc_gazebo/nodes/swerve_control/swerve_control.h
@@ -62,7 +62,8 @@ private:
   double speed_D_fl, speed_D_fr, speed_D_bl, speed_D_br;
   double rate_var;
   double wheel_radius;
-  double max_effort = 0.0;
+  double max_effort;
+  double alpha;
 
   std::vector<controlInfo> motors;
 


### PR DESCRIPTION
# Description

Fixes the [wheel shaking bug](https://www.dropbox.com/s/eyffis97ze1nw5f/swervi_shaking.webm?dl=0) caused by the swervi gazebo PID controller by adding a simple filter to mitigate spikes in derivative value and help mitigate against sensor noise.

This PR does the following:
- Fixes wheel shaking bug by adding simple derivative filter.
- Prevents swervi gazebo controller dividing by zero.

# Testing steps
## Test Case 1
1. Run `roslaunch igvc_gazebo autonav.launch`
2. Zoom in on swerve modules.

Expectation: No evidence of shaking wheels.

## Test Case 2
1. Run `roslaunch igvc_gazebo autonav.launch`
2. Run `rostopic echo /front_left_effort_controller/command`

Expectation: No wildly oscillating effort commands on the `/front_left_effort_controller/command` topic.

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
