### PR TITLE
Feat/joystick driver

### DIFF
--- a/igvc_platform/src/joystick_driver/joystick_driver.cpp
+++ b/igvc_platform/src/joystick_driver/joystick_driver.cpp
@@ -9,13 +9,13 @@ JoystickDriver::JoystickDriver() : nhp{ "~" }
   updater_ptr->setHardwareID("Joystick");
   updater_ptr->add("Joystick Diagnostic", this, &JoystickDriver::joystick_diagnostic);
 
-  assertions::param(nhp, "absoluteMaxVel", absoluteMaxVel, 1.0);
-  assertions::param(nhp, "maxVel", maxVel, 1.6);
-  assertions::param(nhp, "maxVelIncr", maxVelIncr, 0.1);
-  assertions::param(nhp, "leftJoyAxis", leftJoyAxis, 1);
-  assertions::param(nhp, "rightJoyAxis", rightJoyAxis, 4);
-  assertions::param(nhp, "leftInverted", leftInverted, false);
-  assertions::param(nhp, "rightInverted", rightInverted, false);
+  assertions::param(pNh, "absoluteMaxVel", absoluteMaxVel, 1.0);
+  assertions::param(pNh, "maxVel", maxVel, 1.6);
+  assertions::param(pNh, "maxVelIncr", maxVelIncr, 0.1);
+  assertions::param(pNh, "leftJoyAxis", leftJoyAxis, 1);
+  assertions::param(pNh, "rightJoyAxis", rightJoyAxis, 4);
+  assertions::param(pNh, "leftInverted", leftInverted, false);
+  assertions::param(pNh, "rightInverted", rightInverted, false);
 }
 
 void JoystickDriver::joystick_diagnostic(diagnostic_updater::DiagnosticStatusWrapper& stat)
@@ -39,7 +39,7 @@ void JoystickDriver::joyCallback(const sensor_msgs::Joy::ConstPtr& msg)
   maxVel = std::min(maxVel, absoluteMaxVel);
   maxVel = std::max(maxVel, 0.0);
 
-  nhp.setParam("maxVel", maxVel);
+  pNh.setParam("maxVel", maxVel);
 
   updater_ptr->update();
 

--- a/igvc_platform/src/joystick_driver/joystick_driver.cpp
+++ b/igvc_platform/src/joystick_driver/joystick_driver.cpp
@@ -4,24 +4,24 @@ JoystickDriver::JoystickDriver() : nhp{ "~" }
 {
   
   cmd_pub = nh.advertise<igvc_msgs::velocity_pair>("/motors", 1);
-  joy_sub = nh.subscribe("/joy", 1, joyCallback);
+  joy_sub = nh.subscribe("/joy", 1, &JoystickDriver::joyCallback, this);
 
   updater_ptr = std::make_unique<diagnostic_updater::Updater>();
   updater_ptr->setHardwareID("Joystick");
-  updater_ptr->add("Joystick Diagnostic", joystick_diagnostic);
+  updater_ptr->add("Joystick Diagnostic", this, &JoystickDriver::joystick_diagnostic);
 
-  assertions::getParam(pnh, "absoluteMaxVel", absoluteMaxVel, 1.0);
-  assertions::getParam(pnh, "maxVel", maxVel, 1.6);
-  assertions::getParam(pnh, "maxVelIncr", maxVelIncr, 0.1);
-  assertions::getParam(pnh, "leftAxis", leftJoyAxis, 1);
-  assertions::getParam(pnh, "rightAxis", rightJoyAxis, 4);
-  assertions::getParam(pnh, "leftInverted", leftInverted, false);
-  assertions::getParam(pnh, "rightInverted", rightInverted, false);
+  assertions::param(nhp, "absoluteMaxVel", absoluteMaxVel, 1.0);
+  assertions::param(nhp, "maxVel", maxVel, 1.6);
+  assertions::param(nhp, "maxVelIncr", maxVelIncr, 0.1);
+  assertions::param(nhp, "leftAxis", leftJoyAxis, 1);
+  assertions::param(nhp, "rightAxis", rightJoyAxis, 4);
+  assertions::param(nhp, "leftInverted", leftInverted, false);
+  assertions::param(nhp, "rightInverted", rightInverted, false);
 
 
 }
 
-void joystick_diagnostic(diagnostic_updater::DiagnosticStatusWrapper& stat) 
+void JoystickDriver::joystick_diagnostic(diagnostic_updater::DiagnosticStatusWrapper& stat) 
 {
   stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "Joystick Online");
   stat.add("absolute_max_velocity", absoluteMaxVel);
@@ -29,7 +29,7 @@ void joystick_diagnostic(diagnostic_updater::DiagnosticStatusWrapper& stat)
   stat.add("max_velocity_increment", maxVelIncr);
 }
 
-void joyCallback(const sensor_msgs::Joy::ConstPtr& msg) 
+void JoystickDriver::joyCallback(const sensor_msgs::Joy::ConstPtr& msg) 
 {
   if (msg->buttons[1]) {
     maxVel -= maxVelIncr;

--- a/igvc_platform/src/joystick_driver/joystick_driver.cpp
+++ b/igvc_platform/src/joystick_driver/joystick_driver.cpp
@@ -1,51 +1,45 @@
-#include <igvc_msgs/velocity_pair.h>
-#include <ros/publisher.h>
-#include <ros/ros.h>
-#include <ros/subscriber.h>
-#include <sensor_msgs/Joy.h>
-#include <diagnostic_updater/diagnostic_updater.h>
+#include "joystick_driver.h"
 
-#include <memory>
-#include <diagnostic_updater/publisher.h>
+JoystickDriver::JoystickDriver() : nhp{ "~" }
+{
+  
+  cmd_pub = nh.advertise<igvc_msgs::velocity_pair>("/motors", 1);
+  joy_sub = nh.subscribe("/joy", 1, joyCallback);
 
-ros::Publisher cmd_pub;
-ros::NodeHandle* nhp;
-std::unique_ptr<diagnostic_updater::Updater> updater_ptr;
+  updater_ptr = std::make_unique<diagnostic_updater::Updater>();
+  updater_ptr->setHardwareID("Joystick");
+  updater_ptr->add("Joystick Diagnostic", joystick_diagnostic);
 
-void joystick_diagnostic(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  assertions::getParam(pnh, "absoluteMaxVel", absoluteMaxVel, 1.0);
+  assertions::getParam(pnh, "maxVel", maxVel, 1.6);
+  assertions::getParam(pnh, "maxVelIncr", maxVelIncr, 0.1);
+  assertions::getParam(pnh, "leftAxis", leftJoyAxis, 1);
+  assertions::getParam(pnh, "rightAxis", rightJoyAxis, 4);
+  assertions::getParam(pnh, "leftInverted", leftInverted, false);
+  assertions::getParam(pnh, "rightInverted", rightInverted, false);
+
+
+}
+
+void joystick_diagnostic(diagnostic_updater::DiagnosticStatusWrapper& stat) 
 {
   stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "Joystick Online");
-  double absoluteMaxVel, maxVel, maxVelIncr;
-  nhp->param(std::string("absoluteMaxVel"), absoluteMaxVel, 1.0);
-  nhp->param(std::string("maxVel"), maxVel, 1.6);
-  nhp->param(std::string("maxVelIncr"), maxVelIncr, 0.1);
   stat.add("absolute_max_velocity", absoluteMaxVel);
   stat.add("max_velocity", maxVel);
   stat.add("max_velocity_increment", maxVelIncr);
 }
 
-void joyCallback(const sensor_msgs::Joy::ConstPtr& msg)
+void joyCallback(const sensor_msgs::Joy::ConstPtr& msg) 
 {
-  double absoluteMaxVel, maxVel, maxVelIncr;
-  nhp->param(std::string("absoluteMaxVel"), absoluteMaxVel, 1.0);
-  nhp->param(std::string("maxVel"), maxVel, 1.6);
-  nhp->param(std::string("maxVelIncr"), maxVelIncr, 0.1);
-
-  if (msg->buttons[1])
+  if (msg->buttons[1]) {
     maxVel -= maxVelIncr;
-  else if (msg->buttons[3])
+  } else if (msg->buttons[3]) {
     maxVel += maxVelIncr;
+  }
   maxVel = std::min(maxVel, absoluteMaxVel);
   maxVel = std::max(maxVel, 0.0);
 
-  nhp->setParam("maxVel", maxVel);
-
-  int leftJoyAxis, rightJoyAxis;
-  bool leftInverted, rightInverted;
-  nhp->param(std::string("leftAxis"), leftJoyAxis, 1);
-  nhp->param(std::string("rightAxis"), rightJoyAxis, 4);
-  nhp->param(std::string("leftInverted"), leftInverted, false);
-  nhp->param(std::string("rightInverted"), rightInverted, false);
+  nhp.setParam("maxVel", maxVel);
 
   updater_ptr->update();
 
@@ -60,18 +54,6 @@ void joyCallback(const sensor_msgs::Joy::ConstPtr& msg)
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "joystick_driver");
-  ros::NodeHandle nh;
-  nhp = new ros::NodeHandle("~");
-
-  cmd_pub = nh.advertise<igvc_msgs::velocity_pair>("/motors", 1);
-
-  ros::Subscriber joy_sub = nh.subscribe("/joy", 1, joyCallback);
-
-  updater_ptr = std::make_unique<diagnostic_updater::Updater>();
-  updater_ptr->setHardwareID("Joystick");
-  updater_ptr->add("Joystick Diagnostic", joystick_diagnostic);
-
+  JoystickDriver joystick_driver;
   ros::spin();
-  delete nhp;
-  return 0;
 }

--- a/igvc_platform/src/joystick_driver/joystick_driver.cpp
+++ b/igvc_platform/src/joystick_driver/joystick_driver.cpp
@@ -1,6 +1,6 @@
 #include "joystick_driver.h"
 
-JoystickDriver::JoystickDriver() : nhp{ "~" }
+JoystickDriver::JoystickDriver() : pNh{ "~" }
 {
   cmd_pub = nh.advertise<igvc_msgs::velocity_pair>("/motors", 1);
   joy_sub = nh.subscribe("/joy", 1, &JoystickDriver::joyCallback, this);

--- a/igvc_platform/src/joystick_driver/joystick_driver.cpp
+++ b/igvc_platform/src/joystick_driver/joystick_driver.cpp
@@ -2,7 +2,6 @@
 
 JoystickDriver::JoystickDriver() : nhp{ "~" }
 {
-  
   cmd_pub = nh.advertise<igvc_msgs::velocity_pair>("/motors", 1);
   joy_sub = nh.subscribe("/joy", 1, &JoystickDriver::joyCallback, this);
 
@@ -17,11 +16,9 @@ JoystickDriver::JoystickDriver() : nhp{ "~" }
   assertions::param(nhp, "rightAxis", rightJoyAxis, 4);
   assertions::param(nhp, "leftInverted", leftInverted, false);
   assertions::param(nhp, "rightInverted", rightInverted, false);
-
-
 }
 
-void JoystickDriver::joystick_diagnostic(diagnostic_updater::DiagnosticStatusWrapper& stat) 
+void JoystickDriver::joystick_diagnostic(diagnostic_updater::DiagnosticStatusWrapper& stat)
 {
   stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "Joystick Online");
   stat.add("absolute_max_velocity", absoluteMaxVel);
@@ -29,11 +26,14 @@ void JoystickDriver::joystick_diagnostic(diagnostic_updater::DiagnosticStatusWra
   stat.add("max_velocity_increment", maxVelIncr);
 }
 
-void JoystickDriver::joyCallback(const sensor_msgs::Joy::ConstPtr& msg) 
+void JoystickDriver::joyCallback(const sensor_msgs::Joy::ConstPtr& msg)
 {
-  if (msg->buttons[1]) {
+  if (msg->buttons[1])
+  {
     maxVel -= maxVelIncr;
-  } else if (msg->buttons[3]) {
+  }
+  else if (msg->buttons[3])
+  {
     maxVel += maxVelIncr;
   }
   maxVel = std::min(maxVel, absoluteMaxVel);

--- a/igvc_platform/src/joystick_driver/joystick_driver.cpp
+++ b/igvc_platform/src/joystick_driver/joystick_driver.cpp
@@ -12,8 +12,8 @@ JoystickDriver::JoystickDriver() : nhp{ "~" }
   assertions::param(nhp, "absoluteMaxVel", absoluteMaxVel, 1.0);
   assertions::param(nhp, "maxVel", maxVel, 1.6);
   assertions::param(nhp, "maxVelIncr", maxVelIncr, 0.1);
-  assertions::param(nhp, "leftAxis", leftJoyAxis, 1);
-  assertions::param(nhp, "rightAxis", rightJoyAxis, 4);
+  assertions::param(nhp, "leftJoyAxis", leftJoyAxis, 1);
+  assertions::param(nhp, "rightJoyAxis", rightJoyAxis, 4);
   assertions::param(nhp, "leftInverted", leftInverted, false);
   assertions::param(nhp, "rightInverted", rightInverted, false);
 }

--- a/igvc_platform/src/joystick_driver/joystick_driver.h
+++ b/igvc_platform/src/joystick_driver/joystick_driver.h
@@ -14,30 +14,27 @@
 class JoystickDriver
 {
 public:
-    JoystickDriver();
+  JoystickDriver();
 
 private:
+  // node handles
+  ros::NodeHandle nhp;
+  ros::NodeHandle nh;
 
-    //node handles
-    ros::NodeHandle nhp;
-    ros::NodeHandle nh;
+  // publisher
+  ros::Publisher cmd_pub;
 
-    //publisher
-    ros::Publisher cmd_pub;
+  // subscriber
+  ros::Subscriber joy_sub;
 
-    //subscriber
-    ros::Subscriber joy_sub;
+  std::unique_ptr<diagnostic_updater::Updater> updater_ptr;
 
-    std::unique_ptr<diagnostic_updater::Updater> updater_ptr;
+  double absoluteMaxVel, maxVel, maxVelIncr;
+  int leftJoyAxis, rightJoyAxis;
+  bool leftInverted, rightInverted;
 
-    double absoluteMaxVel, maxVel, maxVelIncr;
-    int leftJoyAxis, rightJoyAxis;
-    bool leftInverted, rightInverted;
-
-    void joystick_diagnostic(diagnostic_updater::DiagnosticStatusWrapper& stat);
-    void joyCallback(const sensor_msgs::Joy::ConstPtr& msg);
-
-
+  void joystick_diagnostic(diagnostic_updater::DiagnosticStatusWrapper& stat);
+  void joyCallback(const sensor_msgs::Joy::ConstPtr& msg);
 };
 
-#endif //JOYSTICKDRIVER_H
+#endif  // JOYSTICKDRIVER_H

--- a/igvc_platform/src/joystick_driver/joystick_driver.h
+++ b/igvc_platform/src/joystick_driver/joystick_driver.h
@@ -18,7 +18,7 @@ public:
 
 private:
   // node handles
-  ros::NodeHandle nhp;
+  ros::NodeHandle pNh;
   ros::NodeHandle nh;
 
   // publisher

--- a/igvc_platform/src/joystick_driver/joystick_driver.h
+++ b/igvc_platform/src/joystick_driver/joystick_driver.h
@@ -11,10 +11,10 @@
 #include <memory>
 #include <diagnostic_updater/publisher.h>
 
-class JoystickDirver
+class JoystickDriver
 {
 public:
-    explicit JoystickDriver();
+    JoystickDriver();
 
 private:
 

--- a/igvc_platform/src/joystick_driver/joystick_driver.h
+++ b/igvc_platform/src/joystick_driver/joystick_driver.h
@@ -1,0 +1,43 @@
+#ifndef JOYSTICKDRIVER_H
+#define JOYSTICKDRIVER_H
+
+#include <igvc_msgs/velocity_pair.h>
+#include <ros/publisher.h>
+#include <ros/ros.h>
+#include <ros/subscriber.h>
+#include <sensor_msgs/Joy.h>
+#include <diagnostic_updater/diagnostic_updater.h>
+#include <parameter_assertions/assertions.h>
+#include <memory>
+#include <diagnostic_updater/publisher.h>
+
+class JoystickDirver
+{
+public:
+    explicit JoystickDriver();
+
+private:
+
+    //node handles
+    ros::NodeHandle nhp;
+    ros::NodeHandle nh;
+
+    //publisher
+    ros::Publisher cmd_pub;
+
+    //subscriber
+    ros::Subscriber joy_sub;
+
+    std::unique_ptr<diagnostic_updater::Updater> updater_ptr;
+
+    double absoluteMaxVel, maxVel, maxVelIncr;
+    int leftJoyAxis, rightJoyAxis;
+    bool leftInverted, rightInverted;
+
+    void joystick_diagnostic(diagnostic_updater::DiagnosticStatusWrapper& stat);
+    void joyCallback(const sensor_msgs::Joy::ConstPtr& msg);
+
+
+};
+
+#endif //JOYSTICKDRIVER_H

--- a/igvc_platform/src/tests/test/test_joystick_driver.test
+++ b/igvc_platform/src/tests/test/test_joystick_driver.test
@@ -3,8 +3,8 @@
         <param name="absoluteMaxVel" value="1.2"/>
         <param name="maxVel" value="1.0"/>
         <param name="maxVelIncr" value="0.2"/>
-        <param name="leftAxis" value="1"/>
-        <param name="rightAxis" value="4"/>
+        <param name="leftJoyAxis" value="1"/>
+        <param name="rightJoyAxis" value="4"/>
         <param name="leftInverted" value="false"/>
         <param name="rightInverted" value="false"/>
     </node>

--- a/igvc_platform/src/tests/test/test_joystick_driver.test
+++ b/igvc_platform/src/tests/test/test_joystick_driver.test
@@ -1,4 +1,12 @@
 <launch>
-    <node name="joystick_driver" pkg="igvc_platform" type="joystick_driver" output="screen" required="true"/>
+    <node name="joystick_driver" pkg="igvc_platform" type="joystick_driver" output="screen" required="true">
+        <param name="absoluteMaxVel" value="1.2"/>
+        <param name="maxVel" value="1.0"/>
+        <param name="maxVelIncr" value="0.2"/>
+        <param name="leftAxis" value="1"/>
+        <param name="rightAxis" value="4"/>
+        <param name="leftInverted" value="false"/>
+        <param name="rightInverted" value="false"/>
+    </node>
     <test test-name="test_joystick_driver" pkg="igvc_platform" type="TestJoystickDriver"/>
 </launch>

--- a/igvc_platform/src/tests/test_joystick_driver.cpp
+++ b/igvc_platform/src/tests/test_joystick_driver.cpp
@@ -115,6 +115,57 @@ TEST_F(TestJoystickDriver, HalfSpeedForward)
   EXPECT_EQ(response.right_velocity, half_speed);
 }
 
+TEST_F(TestJoystickDriver, HalfSpeedReverse)
+{
+  MockSubscriber<igvc_msgs::velocity_pair> mock_sub("/motors");
+  ASSERT_TRUE(mock_sub.waitForPublisher());
+  ASSERT_TRUE(mock_sub.waitForSubscriber(mock_joy_pub));
+  const float half_speed = 0.5;
+  mock_joy_pub.publish(createJoyMsg(-half_speed, -half_speed));
+
+  ASSERT_TRUE(mock_sub.spinUntilMessages());
+
+  ASSERT_EQ(mock_sub.messages().size(), 1LU);
+  const igvc_msgs::velocity_pair& response = mock_sub.front();
+
+  EXPECT_EQ(response.left_velocity, -half_speed);
+  EXPECT_EQ(response.right_velocity, -half_speed);
+}
+
+TEST_F(TestJoystickDriver, HalfSpinRight)
+{
+  MockSubscriber<igvc_msgs::velocity_pair> mock_sub("/motors");
+  ASSERT_TRUE(mock_sub.waitForPublisher());
+  ASSERT_TRUE(mock_sub.waitForSubscriber(mock_joy_pub));
+  const float half_speed = 0.5;
+  mock_joy_pub.publish(createJoyMsg(half_speed, -half_speed));
+
+  ASSERT_TRUE(mock_sub.spinUntilMessages());
+
+  ASSERT_EQ(mock_sub.messages().size(), 1LU);
+  const igvc_msgs::velocity_pair& response = mock_sub.front();
+
+  EXPECT_EQ(response.left_velocity, half_speed);
+  EXPECT_EQ(response.right_velocity, -half_speed);
+}
+
+TEST_F(TestJoystickDriver, HalfSpinLeft)
+{
+  MockSubscriber<igvc_msgs::velocity_pair> mock_sub("/motors");
+  ASSERT_TRUE(mock_sub.waitForPublisher());
+  ASSERT_TRUE(mock_sub.waitForSubscriber(mock_joy_pub));
+  const float half_speed = 0.5;
+  mock_joy_pub.publish(createJoyMsg(-half_speed, half_speed));
+
+  ASSERT_TRUE(mock_sub.spinUntilMessages());
+
+  ASSERT_EQ(mock_sub.messages().size(), 1LU);
+  const igvc_msgs::velocity_pair& response = mock_sub.front();
+
+  EXPECT_EQ(response.left_velocity, -half_speed);
+  EXPECT_EQ(response.right_velocity, half_speed);
+}
+
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "test_joystick_driver");


### PR DESCRIPTION
# Description
The igvc_gazebo/joystick driver node is now split into a header and cpp file, with the cpp file containing member function implementations as well as the main function, and retain functionality of the node.

This PR does the following:
- implements the joystick driver node

Fixes #866 

# Testing Steps 
1.) Run `catkin_make run_tests_igvc_platform_rostest_src_tests_test_test_joystick_driver.test`

Expectation: All 8 test cases pass

# Test Case 1
1.) Run `roscore`
2.) Run `roslaunch igvc_platform joystick_driver.launch`
3.) Run `rostopic echo /motors`
4.) Run 
```
rostopic pub /joy sensor_msgs/Joy "header:
  seq: 0
  stamp:
    secs: 0
    nsecs: 0
  frame_id: ''
axes: [1.0,1.0,1.0,1.0,1.0]
buttons: [0,0,0,0,0]" 
```
Expectation: left_velocity: 1.0 and right_velocity: 1.0 (Full Forward)

# Test Case 2
1.) Run `roscore`
2.) Run `roslaunch igvc_platform joystick_driver.launch`
3.) Run `rostopic echo /motors`
4.) Run 
```
rostopic pub /joy sensor_msgs/Joy "header:
  seq: 0
  stamp:
    secs: 0
    nsecs: 0
  frame_id: ''
axes: [1.0,-1.0,1.0,1.0,-1.0]
buttons: [0,0,0,0,0]" 
```
Expectation: left_velocity: -1.0 and right_velocity: -1.0 (Full Reverse)

# Test Case 3
1.) Run `roscore`
2.) Run `roslaunch igvc_platform joystick_driver.launch`
3.) Run `rostopic echo /motors`
4.) Run 
```
rostopic pub /joy sensor_msgs/Joy "header:
  seq: 0
  stamp:
    secs: 0
    nsecs: 0
  frame_id: ''
axes: [1.0,0.0,1.0,1.0,0.0]
buttons: [0,0,0,0,0]" 
```
Expectation: left_velocity: 0.0 and right_velocity: 0.0 (Full Stop)

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behavior works 