### PR TITLE
Swervi camera configuration fix

### DIFF
--- a/igvc_description/urdf/swervi_prop.urdf.xacro
+++ b/igvc_description/urdf/swervi_prop.urdf.xacro
@@ -74,10 +74,10 @@
     <xacro:property name="sensor_mast_z_dim" value="0.05"/>
 
     <!-- Center Camera -->
-    <xacro:property name="center_camera_x" value="0.1"/>
+    <xacro:property name="center_camera_x" value="0.03"/>
     <xacro:property name="center_camera_y" value="0.0"/>
-    <xacro:property name="center_camera_z" value="0.0"/>
-    <xacro:property name="center_camera_pitch" value="0.5"/>
+    <xacro:property name="center_camera_z" value="0.04"/>
+    <xacro:property name="center_camera_pitch" value="0.56"/>
 
     <!-- Left Camera -->
     <xacro:property name="left_camera_x" value="0.0"/>

--- a/igvc_description/urdf/swervi_prop.urdf.xacro
+++ b/igvc_description/urdf/swervi_prop.urdf.xacro
@@ -81,17 +81,17 @@
 
     <!-- Left Camera -->
     <xacro:property name="left_camera_x" value="0.0"/>
-    <xacro:property name="left_camera_y" value="-0.25"/>
-    <xacro:property name="left_camera_z" value="0.0"/>
-    <xacro:property name="left_camera_pitch" value="0.5"/>
-    <xacro:property name="left_camera_yaw" value="-2"/>
+    <xacro:property name="left_camera_y" value="0.25"/>
+    <xacro:property name="left_camera_z" value="0.04"/>
+    <xacro:property name="left_camera_pitch" value="0.56"/>
+    <xacro:property name="left_camera_yaw" value="2.05"/>
 
     <!-- Right Camera -->
     <xacro:property name="right_camera_x" value="0.0"/>
-    <xacro:property name="right_camera_y" value="0.25"/>
-    <xacro:property name="right_camera_z" value="0.0"/>
-    <xacro:property name="right_camera_pitch" value="0.5"/>
-    <xacro:property name="right_camera_yaw" value="2"/>
+    <xacro:property name="right_camera_y" value="-0.25"/>
+    <xacro:property name="right_camera_z" value="0.04"/>
+    <xacro:property name="right_camera_pitch" value="0.56"/>
+    <xacro:property name="right_camera_yaw" value="-2.05"/>
 
     <!-- GPS -->
     <xacro:property name="gps_x" value="0.0"/>


### PR DESCRIPTION
# Description

Currently, the left camera on Swervi shows the right side and the right camera on Swervi shows the left side. This PR fixes the configuration issue and updates the locations of the cameras in line with the actual robot

This PR does the following:
- Fixes camera configuration
- Updates locations of camera to be in line with actual robot.

# Testing steps
## Test Case 1
1. Run `roslaunch igvc_gazebo autonav_low.launch`
2. Verify in rviz that the left and right cameras show the correct sides.

Expectation: Left camera shows the left side of the robot and the right camera shows the right side of the robot.

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
