### PR TITLE
fixed so outputs binary line mask

### DIFF
--- a/igvc_perception/src/multiclass_segmentation/multiclass_segmentation.py
+++ b/igvc_perception/src/multiclass_segmentation/multiclass_segmentation.py
@@ -151,10 +151,20 @@ class SegmentationModel(object):
             pred_mask.astype(np.uint8),
             cv2.COLOR_GRAY2BGR
         )
+
+        # Multiclass Segmentation Visualization
+        # lineMask = np.all(colorImg == [2, 2, 2], axis=2)
+        # colorImg[lineMask] = [255, 255, 255]
+        # barrelMask = np.all(colorImg == [1, 1, 1], axis=2)
+        # colorImg[barrelMask] = [0, 255, 0]
+        # msg_out = self.bridge.cv2_to_imgmsg(colorImg, 'bgr8')
+        # msg_out.header.stamp = data.header.stamp
+        # self.im_publishers[camera_name].publish(msg_out)
+
+        # Producing Binary Mask for lines
         lineMask = np.all(colorImg == [2, 2, 2], axis=2)
         colorImg[lineMask] = [255, 255, 255]
-        barrelMask = np.all(colorImg == [1, 1, 1], axis=2)
-        colorImg[barrelMask] = [0, 255, 0]
+        colorImg[~lineMask] = [0, 0, 0]
         msg_out = self.bridge.cv2_to_imgmsg(colorImg, 'bgr8')
         msg_out.header.stamp = data.header.stamp
         self.im_publishers[camera_name].publish(msg_out)


### PR DESCRIPTION
# Description

Fixes Multiclass Segmentation script so it outputs a binary mask of the lines

This PR does the following:
- Multiclass Segmentation now outputs a binary mask

# Testing steps
## Test Case 1
1. trust me bro

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
