### PR TITLE
Ignore ipynb spam

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-detectable=false


### PR DESCRIPTION
# Description

Adds a .gitattributes file to stop the ipynb spam in the code base composition

Expectation: Codebase makeup correct

# Self Checklist
- [x] I have formatted my code using `make format`
- [x] I have tested that the new behaviour works 
